### PR TITLE
Add git Dependency to stackstorm Dockerfile

### DIFF
--- a/stackstorm/Dockerfile
+++ b/stackstorm/Dockerfile
@@ -3,7 +3,7 @@ FROM debian:wheezy
 ARG ST2_VERSION
 LABEL com.stackstorm.version="${ST2_VERSION}"
 
-RUN apt-get -y update && apt-get -y install adduser procps python2.7 libffi5 libyaml-0-2
+RUN apt-get -y update && apt-get -y install adduser procps python2.7 libffi5 libyaml-0-2 git
 
 ADD ./st2bundle*.deb /tmp/
 RUN dpkg -i /tmp/st2bundle*.deb && rm -r /tmp/* && apt-get clean


### PR DESCRIPTION
Failed Build https://circleci.com/gh/StackStorm/st2/362
```
dpkg: dependency problems prevent configuration of st2bundle:
 st2bundle depends on git; however:
  Package git is not installed.

dpkg: error processing st2bundle (--install):
 dependency problems - leaving unconfigured
Errors were encountered while processing:
 st2bundle
```