### PR TITLE
Add net-tools for packagingrunner, needed by Rspec

### DIFF
--- a/packagingrunner/Dockerfile.template
+++ b/packagingrunner/Dockerfile.template
@@ -2,7 +2,7 @@ FROM quay.io/dennybaa/droneruby:{{ suite }}-rbenv
 
 # Additional software (needed for RSpec, serverspec)
 RUN DEBIAN_FRONTEND=noninteractive && apt-get -y update && \
-    apt-get -y install netcat && apt-get -y clean
+    apt-get -y install netcat net-tools && apt-get -y clean
 
 ADD Gemfile /root/Gemfile
 


### PR DESCRIPTION
`net-tools` provides `netstat` binary, needed for some Rspec tests here: https://github.com/StackStorm/st2-packages/issues/103

@dennybaa can you update all `droneunit` Docker images and include `netstat` there?
They're all here under your control: https://quay.io/repository/dennybaa/droneunit