### PR TITLE
Rename st2bundle to st2

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,20 +61,20 @@ In production use case you can direct configuration passing.
 Here is an example to build all StackStorm components and deploy them to Docker Hub.
 It shows current automated CI & Deployment logic.
 
-##### 1. Build `st2bundle`
+##### 1. Build `st2`
 This is base image, which will be used as parent for StackStorm components.
 
 ```
-# copy st2bundle deb package to directory where base Dockerfile is located
-cp /tmp/st2-packages/st2bundle*.deb stackstorm/
+# copy st2 deb package to directory where base Dockerfile is located
+cp /tmp/st2-packages/st2*.deb stackstorm/
 
 # note that version argument is required (make sure you have Docker 1.9+ installed for [this feature](https://docs.docker.com/engine/reference/commandline/build/#set-build-time-variables-build-arg))
-docker build --build-arg ST2_VERSION="1.1.2-5" -t st2bundle stackstorm/
+docker build --build-arg ST2_VERSION="1.1.2-5" -t st2 stackstorm/
 ```
 where `1.1.2` is version and `5` is revision numbers (more metadata like this will be added later to Docker images).
 
 ##### 2. Build StackStorm components from the Base image
-Once we have `st2bundle` base Docker image, we can build child containers from it. Do for all StackStorm components:
+Once we have `st2` base Docker image, we can build child containers from it. Do for all StackStorm components:
 ```
 docker build -t stackstorm/st2actionrunner:1.1.2 st2actionrunner/
 docker build -t stackstorm/st2api:1.1.2 st2api/

--- a/st2actionrunner/Dockerfile
+++ b/st2actionrunner/Dockerfile
@@ -1,4 +1,4 @@
-FROM st2bundle
+FROM st2
 LABEL com.stackstorm.service.provides="actionrunner"
 
 ENV ST2_SERVICE st2actionrunner

--- a/st2api/Dockerfile
+++ b/st2api/Dockerfile
@@ -1,4 +1,4 @@
-FROM st2bundle
+FROM st2
 LABEL com.stackstorm.service.provides="api"
 
 ENV ST2_SERVICE st2api

--- a/st2auth/Dockerfile
+++ b/st2auth/Dockerfile
@@ -1,4 +1,4 @@
-FROM st2bundle
+FROM st2
 LABEL com.stackstorm.service.provides="auth"
 
 ENV ST2_SERVICE st2auth

--- a/st2exporter/Dockerfile
+++ b/st2exporter/Dockerfile
@@ -1,4 +1,4 @@
-FROM st2bundle
+FROM st2
 LABEL com.stackstorm.service.provides="exporter"
 
 ENV ST2_SERVICE st2exporter

--- a/st2notifier/Dockerfile
+++ b/st2notifier/Dockerfile
@@ -1,4 +1,4 @@
-FROM st2bundle
+FROM st2
 LABEL com.stackstorm.service.provides="notifier"
 
 ENV ST2_SERVICE st2notifier

--- a/st2resultstracker/Dockerfile
+++ b/st2resultstracker/Dockerfile
@@ -1,4 +1,4 @@
-FROM st2bundle
+FROM st2
 LABEL com.stackstorm.service.provides="resultstracker"
 
 ENV ST2_SERVICE st2resultstracker

--- a/st2rulesengine/Dockerfile
+++ b/st2rulesengine/Dockerfile
@@ -1,4 +1,4 @@
-FROM st2bundle
+FROM st2
 LABEL com.stackstorm.service.provides="rulesengine"
 
 ENV ST2_SERVICE st2rulesengine

--- a/st2sensorcontainer/Dockerfile
+++ b/st2sensorcontainer/Dockerfile
@@ -1,4 +1,4 @@
-FROM st2bundle
+FROM st2
 LABEL com.stackstorm.service.provides="sensorcontainer"
 
 ENV ST2_SERVICE st2sensorcontainer

--- a/stackstorm/Dockerfile
+++ b/stackstorm/Dockerfile
@@ -5,8 +5,8 @@ LABEL com.stackstorm.version="${ST2_VERSION}"
 
 RUN apt-get -y update && apt-get -y install adduser procps python2.7 libffi5 libyaml-0-2 git libpcre3 libpython2.7 libxml2 python-dev libssl-dev libffi-dev
 
-ADD ./st2bundle*.deb /tmp/
-RUN dpkg -i /tmp/st2bundle*.deb && rm -r /tmp/* && apt-get clean
+ADD ./st2*.deb /tmp/
+RUN dpkg -i /tmp/st2*.deb && rm -r /tmp/* && apt-get clean
 
 ADD ./conf/st2.conf.template /st2.conf.template
 RUN md5sum /etc/st2/st2.conf > /st2.conf.orig.md5

--- a/stackstorm/Dockerfile
+++ b/stackstorm/Dockerfile
@@ -5,8 +5,8 @@ LABEL com.stackstorm.version="${ST2_VERSION}"
 
 RUN apt-get -y update && apt-get -y install adduser procps python2.7 libffi5 libyaml-0-2 git libpcre3 libpython2.7 libxml2 python-dev libssl-dev libffi-dev
 
-ADD ./st2*.deb /tmp/
-RUN dpkg -i /tmp/st2*.deb && rm -r /tmp/* && apt-get clean
+ADD ./st2_*.deb /tmp/
+RUN dpkg -i /tmp/st2_*.deb && rm -r /tmp/* && apt-get clean
 
 ADD ./conf/st2.conf.template /st2.conf.template
 RUN md5sum /etc/st2/st2.conf > /st2.conf.orig.md5


### PR DESCRIPTION
Part of https://github.com/StackStorm/st2-packages/pull/131 base package rename from `st2bundle` to `st2`.
