### PR TITLE
Make containers wait for required services before starting

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,17 +21,20 @@ There many ways to set this configuration, namely:
  - Using environment variables.
  - Using docker links.
  - Passing `/etc/st2/st2.conf` as volume.
- 
+
 These ways are sufficient for any use case, starting from a small docker compose development environment finishing with big discovery managed installations. Let's cover these.
 
 ### Using environment variables
 
 St2 components the following environment variables:
 
- - **AMQP_URL** - url of rabbitmq, **default** is: `amqp://guest:guest@rabbitmq:5672/`.
+ - **AMQP_HOST** - rabbitmq hostname, **default** is: `rabbitmq`.
+ - **AMQP_PORT** - rabbitmq port, **default** is: `5672`.
+ - **AMQP_USER** - rabbitmq user, **default** is: `guest`.
+ - **AMQP_PASSWORD** - rabbitmq password, **default** is: `guest`.
  - **DB_HOST** - mongo database hostname or ip address, **default** is: `mongo`.
  - **DB_PORT** - mongo database listen port, **default** is: `27017`.
- - **API_URL** - stackstorm api endpoint. 
+ - **API_URL** - stackstorm api endpoint.
 
 If you need any custom configuration, simple pass these environment variables to st2 docker containers and you are ready to go.
 

--- a/st2actionrunner/Dockerfile
+++ b/st2actionrunner/Dockerfile
@@ -2,4 +2,6 @@ FROM st2
 LABEL com.stackstorm.service.provides="actionrunner"
 
 ENV ST2_SERVICE st2actionrunner
+ENV ST2_REQUIRE_AMQP 1
+
 VOLUME [ "/home/stanley/.ssh/id_rsa" ]

--- a/st2api/Dockerfile
+++ b/st2api/Dockerfile
@@ -2,4 +2,6 @@ FROM st2
 LABEL com.stackstorm.service.provides="api"
 
 ENV ST2_SERVICE st2api
+ENV ST2_REQUIRE_AMQP 1
+
 EXPOSE 9101

--- a/st2notifier/Dockerfile
+++ b/st2notifier/Dockerfile
@@ -2,3 +2,4 @@ FROM st2
 LABEL com.stackstorm.service.provides="notifier"
 
 ENV ST2_SERVICE st2notifier
+ENV ST2_REQUIRE_AMQP 1

--- a/st2resultstracker/Dockerfile
+++ b/st2resultstracker/Dockerfile
@@ -2,3 +2,4 @@ FROM st2
 LABEL com.stackstorm.service.provides="resultstracker"
 
 ENV ST2_SERVICE st2resultstracker
+ENV ST2_REQUIRE_AMQP 1

--- a/st2rulesengine/Dockerfile
+++ b/st2rulesengine/Dockerfile
@@ -2,3 +2,4 @@ FROM st2
 LABEL com.stackstorm.service.provides="rulesengine"
 
 ENV ST2_SERVICE st2rulesengine
+ENV ST2_REQUIRE_AMQP 1

--- a/st2sensorcontainer/Dockerfile
+++ b/st2sensorcontainer/Dockerfile
@@ -2,3 +2,4 @@ FROM st2
 LABEL com.stackstorm.service.provides="sensorcontainer"
 
 ENV ST2_SERVICE st2sensorcontainer
+ENV ST2_REQUIRE_AMQP 1

--- a/stackstorm/Dockerfile
+++ b/stackstorm/Dockerfile
@@ -3,7 +3,7 @@ FROM debian:wheezy
 ARG ST2_VERSION
 LABEL com.stackstorm.version="${ST2_VERSION}"
 
-RUN apt-get -y update && apt-get -y install adduser procps python2.7 libffi5 libyaml-0-2 git libpcre3 libpython2.7 libxml2 python-dev libssl-dev libffi-dev
+RUN apt-get -y update && apt-get -y install adduser procps python2.7 libffi5 libyaml-0-2 git libpcre3 libpython2.7 libxml2 python-dev libssl-dev libffi-dev sudo netcat
 
 ADD ./st2_*.deb /tmp/
 RUN dpkg -i /tmp/st2_*.deb && rm -r /tmp/* && apt-get clean

--- a/stackstorm/docker-entrypoint.sh
+++ b/stackstorm/docker-entrypoint.sh
@@ -1,9 +1,28 @@
 #!/bin/bash
 
 # We expect docker links with default names: rabbitmq, mongo
-amqp_url="${AMQP_URL:-amqp://guest:guest@rabbitmq:5672/}"
+amqp_host="${AMQP_HOST:-rabbitmq}"
+amqp_port="${AMQP_PORT:-5672}"
+amqp_user="${AMQP_USER:-guest}"
+amqp_password="${AMQP_PASSWORD:-guest}"
+amqp_url="amqp://$amqp_user:$amqp_password@$amqp_host:$amqp_port/"
+
+if [ -n $ST2_REQUIRE_AMQP ]; then
+  until nc -z $amqp_host $amqp_port; do
+    echo "AMQP at $amqp_host:$amqp_port doesn't respond. Waiting..."
+    sleep 1
+  done
+fi
+
 db_host="${DB_HOST:-mongo}"
 db_port="${DB_PORT:-27017}"
+
+if [ -n $ST2_REQUIRE_DB ]; then
+  until nc -z $db_host $db_port; do
+    echo "DB at $db_host:$db_port doesn't respond. Waiting..."
+    sleep 1
+  done
+fi
 
 # Check *_PORT variable if container is linked
 linked_service() { [[ "$1" != tcp://* ]] && return 1; return 0; }


### PR DESCRIPTION
One of the problems I wasn't able to handle in st2box alone is the fact containers deployed with `docker-compose` are starting in a semi-random order and usually require some time before they'll become fully operational. This results in a flood of error messages, need to restart containers over and over and quiet failure of some features (ex. chatops won't reconnect to stream if it was unable to do it the first time).

`Docker-compose` provides no wait functionality by itself so we have to add it to containers themselves. Simply checking with `netcat` if the port is responding seems to be enough in all the cases I've seen. 

The trade off is that it will become impossible to run unmodified container without having a dependency in place. I personally see no reason for anyone to do that since it would fail anyway, but I might be missing something.
