### PR TITLE
Build docker containers standalone

### DIFF
--- a/.circle/docker.sh
+++ b/.circle/docker.sh
@@ -1,0 +1,68 @@
+#!/bin/bash
+set -e
+
+### Pass these ENV Variables for this script to consume:
+# DEPLOY_DOCKER - Should this script push created images to Docker Hub? (0/1)
+
+# DOCKER_USER - Docker Hub Username to login
+# DOCKER_EMAIL - Docker Hub Email to login
+# DOCKER_PASSWORD - Docker Hub Password to Login
+
+# ST2_GITREV - st2 branch name (ex: master, v1.2.1). This will be used to determine correct Docker Tag: `latest`, `1.2.1`
+# ST2PKG_VERSION - st2 version, will be reused in Docker image metadata (ex: 1.2dev)
+# ST2PKG_RELEASE - Release number aka revision number for `st2` package, will be reused in Docker metadata (ex: 4)
+
+### Usage:
+# docker.sh build st2 - Build base Docker image with `st2` installed. This will be reused by child containers
+# docker.sh build st2actionrunner st2api st2auth st2exporter st2notifier st2resultstracker st2rulesengine st2sensorcontainer - Build child Docker images based on `st2`, - previously created Docker image
+# docker.sh run st2api - Start detached `st2api` docker image
+# docker.sh test st2api 'st2 --version' - Exec command inside already started `st2api` Docker container
+# docker.sh deploy st2api st2auth st2exporter st2notifier st2resultstracker st2rulesengine st2sensorcontainer - Push images to Docker Hub
+
+: ${DEPLOY_DOCKER:=1}
+
+# Required ENV variables
+: ${ST2PKG_VERSION:? ST2PKG_VERSION env is required}
+: ${ST2PKG_RELEASE:? ST2PKG_RELEASE env is required}
+: ${ST2PKG_STAGING:=1}
+
+case "$1" in
+  build)
+    case "$2" in
+      st2)
+        : ${pkgsgaging:=$([ $ST2PKG_STAGING -gt 0 ] && echo 'staging-')}
+        : ${pkgrepo:=$(echo ${ST2PKG_VERSION} | grep -q 'dev' && echo 'unstable' || echo 'stable')}
+        docker build --build-arg ST2_VERSION="${ST2PKG_VERSION}-${ST2PKG_RELEASE}" --build-arg ST2_REPO="${pkgsgaging}${pkgrepo}" -t st2 stackstorm/
+      ;;
+      *)
+        for container in "${@:2}"; do
+          docker build -t stackstorm/${container}:latest ${container}
+        done
+      ;;
+    esac
+  ;;
+  run)
+    docker run --name "$2" -d stackstorm/"$2":latest
+  ;;
+  test)
+    # Verify Container by running `st2` command in it
+    # Same as: docker exec st2docker st2 --version
+    # See: https://circleci.com/docs/docker#docker-exec
+    sudo lxc-attach -n "$(docker inspect --format '{{.Id}}' ${2})" -- bash -c "${3}"
+  ;;
+  deploy)
+    if [ ${DEPLOY_DOCKER} -eq 0 ]; then
+      echo 'Skipping Docker push because DEPLOY_DOCKER=0'
+      exit
+    fi
+
+    for container in "${@:2}"; do
+      docker tag stackstorm/${container}:latest stackstorm/${container}:${ST2PKG_VERSION}
+    done
+
+    docker login -u ${DOCKER_USER} -p ${DOCKER_PASSWORD}
+
+    echo 'Pushing StackStorm images to Docker Hub in parallel ...'
+    parallel -v -j0 --line-buffer docker push stackstorm/{}:${ST2PKG_VERSION} ::: ${@:2}
+  ;;
+esac

--- a/circle.yml
+++ b/circle.yml
@@ -1,0 +1,49 @@
+# Setup in CircleCI account the following ENV variables:
+general:
+  artifacts:
+    - ~/logs
+
+machine:
+  # Overwrite these ENV variables in parametrized (manual/API) builds
+  environment:
+    ST2PKG_VERSION: 1.6dev
+    ST2PKG_RELEASE: 30
+    ST2PKG_STAGING: 1
+    ST2_COMPONENTS: st2actionrunner st2api st2stream st2auth st2exporter st2notifier st2resultstracker st2rulesengine st2sensorcontainer
+    DEPLOY_DOCKER: 0
+  pre:
+    - mkdir -p ~/logs
+    # Need latest Docker version for features like `--build-arg` to work (CircleCI by default works with outdated version)
+    - |
+      sudo curl -L -o /usr/bin/docker 'http://s3-external-1.amazonaws.com/circle-downloads/docker-1.9.0-circleci'
+      sudo chmod 0755 /usr/bin/docker
+  services:
+    - docker
+
+dependencies:
+  pre:
+    - sudo apt-get update
+    - sudo apt-get -y install parallel jq
+    - sudo pip install docker-compose
+    - docker-compose version
+    - docker version
+
+test:
+  pre:
+    - .circle/docker.sh build st2
+    - .circle/docker.sh build $ST2_COMPONENTS
+    - docker-compose up -d
+  override:
+    - docker-compose run client st2 action list --pack=core
+    - docker-compose run client st2 run core.noop
+    - docker-compose run client st2 run core.local -- date -R
+
+deployment:
+  publish:
+    branch:
+      - master
+      - /v[0-9]+\.[0-9]+/
+      - feature/circleci
+    owner: StackStorm
+    commands:
+      - .circle/docker.sh deploy $ST2_COMPONENTS

--- a/st2stream/Dockerfile
+++ b/st2stream/Dockerfile
@@ -1,0 +1,5 @@
+FROM st2
+LABEL com.stackstorm.service.provides="stream"
+
+ENV ST2_SERVICE st2stream
+EXPOSE 9102

--- a/stackstorm/Dockerfile
+++ b/stackstorm/Dockerfile
@@ -1,11 +1,14 @@
 FROM debian:wheezy
 
 ARG ST2_VERSION
+ARG ST2_REPO=stable
+ARG ST2_PACKAGE=https://packagecloud.io/StackStorm/${ST2_REPO}/packages/debian/wheezy/st2_${ST2_VERSION}_amd64.deb/download
+
 LABEL com.stackstorm.version="${ST2_VERSION}"
 
-RUN apt-get -y update && apt-get -y install adduser procps python2.7 libffi5 libyaml-0-2 git libpcre3 libpython2.7 libxml2 python-dev libssl-dev libffi-dev
+RUN apt-get -y update && apt-get -y install adduser procps python2.7 libffi5 libyaml-0-2 git libpcre3 libpython2.7 libxml2 python-dev libssl-dev libffi-dev sudo
 
-ADD ./st2_*.deb /tmp/
+ADD ${ST2_PACKAGE} /tmp/st2_${ST2_VERSION}_amd64.deb
 RUN dpkg -i /tmp/st2_*.deb && rm -r /tmp/* && apt-get clean
 
 ADD ./conf/st2.conf.template /st2.conf.template


### PR DESCRIPTION
Previously we did it as a part of packaging process which made it unacceptably slow. This changes would allow us to build containers on demand by calling a webhook.