### PR TITLE
Pin MongoDB to 3.2

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -79,7 +79,7 @@ actionrunner:
 
 ## External Services
 mongo:
-  image: mongo
+  image: mongo:3.2
 
 rabbitmq:
   image: rabbitmq


### PR DESCRIPTION
Newer MongoDB is not compatible with StackStorm.
Pinning it to `3.2`

Thanks to @enykeev for finding out https://github.com/StackStorm/st2box/commit/bee826b8d58472a02345897c0f26bc7089276eb7