### PR TITLE
enables to handle multibyte characters in the test environment of 'wheezy' and 'jessie'

### DIFF
--- a/packagingtest/jessie/sshd/Dockerfile
+++ b/packagingtest/jessie/sshd/Dockerfile
@@ -27,6 +27,10 @@ RUN echo -e "#!/bin/sh\nexit 101\n" > /usr/sbin/policy-rc.d && \
     apt-get -y install gdebi-core sshpass cron \
       netcat net-tools
 
+# install locales package and set default locale to 'UTF-8' for the test executiong environment
+RUN apt-get -y update && apt-get -y install locales && \
+    echo 'en_US.UTF-8 UTF-8' > /etc/locale.gen && locale-gen
+
 ENV container docker
 
 # we can have ssh

--- a/packagingtest/wheezy/sshd/Dockerfile
+++ b/packagingtest/wheezy/sshd/Dockerfile
@@ -27,6 +27,10 @@ RUN echo -e "#!/bin/sh\nexit 101\n" > /usr/sbin/policy-rc.d && \
     apt-get -y install gdebi-core sshpass cron \
       netcat net-tools
 
+# install locales package and set default locale to 'UTF-8' for the test executiong environment
+RUN apt-get -y update && apt-get -y install locales && \
+    echo 'en_US.UTF-8 UTF-8' > /etc/locale.gen && locale-gen
+
 ENV container docker
 
 # we can have ssh


### PR DESCRIPTION
This is the correction of test failure which is occurred in [this PR](https://github.com/StackStorm/st2-packages/pull/402).

This patch installs 'locales' package and set default locale to 'UTF-8'.

By this patch, the test environment which is deploied in 'packagingtest' container will be able to handle multibyte characters in command-line arguments.

Thank you.
