### PR TITLE
Fix multi-user on centos7 packagingtest

### DIFF
--- a/packagingtest/centos7/systemd/Dockerfile
+++ b/packagingtest/centos7/systemd/Dockerfile
@@ -79,7 +79,6 @@ RUN yum -y update; \
     yum -y install systemd; yum clean all;
 
 RUN cd /lib/systemd/system/sysinit.target.wants/; ls -1 | grep -v systemd-tmpfiles-setup.service | xargs rm; \
-    rm -f /lib/systemd/system/multi-user.target.wants/*;\
     rm -f /etc/systemd/system/*.wants/*;\
     rm -f /lib/systemd/system/local-fs.target.wants/*; \
     rm -f /lib/systemd/system/sockets.target.wants/*udev*; \


### PR DESCRIPTION
Fix option which prevented additional users to SSH login on `packagingtest` centos7 systemd Docker image.

https://travis-ci.org/StackStorm/ansible-st2/jobs/200035411
```sh
       Waiting for SSH service on localhost:32768, retrying in 3 seconds
       Waiting for SSH service on localhost:32768, retrying in 3 seconds
       Waiting for SSH service on localhost:32768, retrying in 3 seconds
       Waiting for SSH service on localhost:32768, retrying in 3 seconds
       Waiting for SSH service on localhost:32768, retrying in 3 seconds
       Waiting for SSH service on localhost:32768, retrying in 3 seconds
$$$$$$ [SSH] connection failed, terminating (#<Net::SSH::Disconnect: connection closed by remote host>)
```

`packagingtest` Docker images are used in `ansible-st2` Test-Kitchen + Travis CI, which creates `kitchen` user to run all tests.

See: https://github.com/StackStorm/ansible-st2/pull/115 for more info