### PR TITLE
README for 'packagingbuild' and 'packagingtest' Dockerfiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 # StackStorm Docker Containers
 [![Circle CI Build Status](https://circleci.com/gh/StackStorm/st2-dockerfiles/tree/master.svg?style=shield)](https://circleci.com/gh/StackStorm/st2-dockerfiles)
-[![Go to Quay.io for packagingenv images](https://img.shields.io/badge/Quay-packagingenv-blue.svg)](https://quay.io/repository/stackstorm/packagingenv)
-[![Go to Quay.io for packagingtest images](https://img.shields.io/badge/Quay-packagingtest-blue.svg)](https://quay.io/repository/stackstorm/packagingtest)
 [![Go to Docker Hub](https://img.shields.io/badge/Docker%20Hub-%E2%86%92-blue.svg)](https://hub.docker.com/r/stackstorm/)
 
 > *Warning:*  Docker is not officially supported by StackStorm.<br>

--- a/README.md
+++ b/README.md
@@ -105,3 +105,13 @@ docker push stackstorm/st2sensorcontainer:2.0.1
 docker push stackstorm/st2garbagecollector:2.0.1
 ```
 
+## Also in this repo
+### `packagingbuild`
+`Dockerfiles` with ready to use environment to build `.deb` and `.rpm` StackStorm packages in [StackStorm/st2-packages](https://github.com/StackStorm/st2-packages/blob/master/docker-compose.circle.yml) CI/CD.
+
+See [packagingbuild/](packagingbuild/)
+
+### `packagingtest`
+`Dockerfiles` with pre-installed init system used to test `.deb` and `.rpm` StackStorm packages in [StackStorm/st2-packages](https://github.com/StackStorm/st2-packages/blob/master/docker-compose.circle.yml) CI/CD.
+
+See [packagingtest/](packagingtest/)

--- a/packagingbuild/README.md
+++ b/packagingbuild/README.md
@@ -1,0 +1,17 @@
+# Packagingbuild Dockerfiles
+[![Go to packagingbuild Docker Hub](https://img.shields.io/badge/Docker%20Hub-packagingbuild-blue.svg)](https://hub.docker.com/r/stackstorm/packagingbuild/)
+
+Docker images used to build `.deb` and `.rpm` StackStorm packages in [StackStorm/st2-packages](https://github.com/StackStorm/st2-packages/blob/master/docker-compose.circle.yml) CI/CD.
+
+In these containers build environment specific for each OS distro is pre-installed and respective StackStorm packages are built for each platform.
+
+[`Dockerfiles` sources](https://github.com/StackStorm/st2-dockerfiles/blob/master/packagingbuild):
+- Debian Wheezy
+- Debian Jessie
+- CentOS 6
+- CentOS 7
+- Ubuntu Trusty
+- Ubuntu Xenial
+
+NB!
+Images are built automatically in Docker Hub on every push to [StackStorm/st2-dockerfiles](https://github.com/StackStorm/st2-dockerfiles/) `master`.

--- a/packagingtest/README.md
+++ b/packagingtest/README.md
@@ -1,0 +1,17 @@
+# Packagintest Dockerfiles
+[![Go to packagingtest Docker Hub](https://img.shields.io/badge/Docker%20Hub-packagingtest-blue.svg)](https://hub.docker.com/r/stackstorm/packagingtest/)
+
+Docker images with pre-installed init system used to test `.deb` and `.rpm` StackStorm packages in [StackStorm/st2-packages](https://github.com/StackStorm/st2-packages/blob/master/docker-compose.circle.yml) CI/CD.
+
+In these containers built artifacts are tested: StackStorm packages are installed, configuration is written, dependent services like MongoDB, RabbitMQ, PostgreSQL are started and end-to-end tests are performed, like on real OS with specific init system.
+
+[`Dockerfiles` sources](https://github.com/StackStorm/st2-dockerfiles/blob/master/packagingtest):
+- Debian Wheezy (ssh)
+- Debian Jessie (sshd)
+- CentOS 6 (sshd)
+- CentOS 7 (systemd)
+- Ubuntu Trusty (upstart)
+- Ubuntu Xenial (systemd)
+
+NB!
+Images are built automatically on every push to [StackStorm/st2-dockerfiles](https://github.com/StackStorm/st2-dockerfiles/) `master`.


### PR DESCRIPTION
Add README for `packagingbuild` and `packagingtest` Dockerfiles, which are used to `build` and `test` StackStorm packages in `st2-packages` CI/CD.

The entire story might be very confusing for someone new, - bring better explanations and descriptions.