### PR TITLE
Ensure locale is set to en_US.UTF-8

### DIFF
--- a/packagingtest/centos7/systemd/Dockerfile
+++ b/packagingtest/centos7/systemd/Dockerfile
@@ -71,6 +71,11 @@ RUN sed -ri 's/^session\s+required\s+pam_loginuid.so$/session optional pam_login
         sed -ri 's/requiretty/!requiretty/' /etc/sudoers && \
         echo 'root:docker.io' | chpasswd
 
+# Set default locale to 'UTF-8' for the test execution environment
+# Per https://github.com/CentOS/sig-cloud-instance-images/issues/71
+RUN sed -ri 's/langs=en_US.UTF-8/langs=en_US.utf8/' yum.conf && \
+    yum reinstall -y glibc-common
+
 RUN yum -y install nc net-tools
 
 ENV container docker

--- a/packagingtest/xenial/systemd/Dockerfile
+++ b/packagingtest/xenial/systemd/Dockerfile
@@ -21,6 +21,11 @@ RUN sed -ri 's/^session\s+required\s+pam_loginuid.so$/session optional pam_login
         sed -ri 's/requiretty/!requiretty/' /etc/sudoers && \
         echo 'root:docker.io' | chpasswd
 
+# install locales package and set default locale to 'UTF-8' for the
+# test execution environment
+RUN apt-get -y update && apt-get -y install locales && \
+    echo 'en_US.UTF-8 UTF-8' > /etc/locale.gen && locale-gen
+
 # install core software for packaging and ssh communication
 RUN echo -e "#!/bin/sh\nexit 101\n" > /usr/sbin/policy-rc.d && \
     DEBIAN_FRONTEND=noninteractive && apt-get -y update && \


### PR DESCRIPTION
The `locale` is not setup correctly on `xenial` and `el7`, which leads to a couple failed tests in our `docker-compose` environment. For example:

```
==> el7: status: failed
==> el7: parameters: 
==> el7:   cmd: "echo '??_(???)_/??'"
==> el7: result: 
==> el7:   error: '''ascii'' codec can''t encode character u''??'' in position 44: ordinal not in range(128)'
```

Merely `exec`'ing into the `vagrant_centos7test_1` container (see https://github.com/StackStorm/st2-packages) and running `/bin/bash`, we see:

```
[vagrant@st2-packages-el7 ~]$ docker exec -it vagrant_centos7test_1 /bin/bash
bash: warning: setlocale: LC_CTYPE: cannot change locale (en_US.UTF-8): No such file or directory
bash: warning: setlocale: LC_COLLATE: cannot change locale (en_US.UTF-8): No such file or directory
bash: warning: setlocale: LC_MESSAGES: cannot change locale (en_US.UTF-8): No such file or directory
bash: warning: setlocale: LC_NUMERIC: cannot change locale (en_US.UTF-8): No such file or directory
bash: warning: setlocale: LC_TIME: cannot change locale (en_US.UTF-8): No such file or directory
```

We now explicitly set the locale to `en_US.UTF-8`.