### PR TITLE
Specify yum.conf using absolute path

### DIFF
--- a/packagingtest/centos7/systemd/Dockerfile
+++ b/packagingtest/centos7/systemd/Dockerfile
@@ -73,7 +73,7 @@ RUN sed -ri 's/^session\s+required\s+pam_loginuid.so$/session optional pam_login
 
 # Set default locale to 'UTF-8' for the test execution environment
 # Per https://github.com/CentOS/sig-cloud-instance-images/issues/71
-RUN sed -ri 's/langs=en_US.UTF-8/langs=en_US.utf8/' yum.conf && \
+RUN sed -ri 's/langs=en_US.UTF-8/langs=en_US.utf8/' /etc/yum.conf && \
     yum reinstall -y glibc-common
 
 RUN yum -y install nc net-tools


### PR DESCRIPTION
The absolute path to `yum.conf` needs to be specified, otherwise `sed` cannot find it.