### PR TITLE
Rebuild packagingrunner Docker container

### DIFF
--- a/packagingrunner/trusty/Dockerfile
+++ b/packagingrunner/trusty/Dockerfile
@@ -1,7 +1,7 @@
 FROM quay.io/dennybaa/droneruby:trusty-rbenv
 
 # Additional software (needed for RSpec, serverspec)
-RUN DEBIAN_FRONTEND=noninteractive && apt-get -y update && \
+RUN DEBIAN_FRONTEND=noninteractive && apt-get -y update && apt-get -y upgrade && \
     apt-get -y install netcat && apt-get -y clean
 
 ADD Gemfile /root/Gemfile


### PR DESCRIPTION
It will update ruby 'serverspec' that fixes the bug when serverspec tests didn't catch enabled services under Xenial systemd

See https://circleci.com/gh/StackStorm/st2/3910#tests/containers/1
![](https://i.imgur.com/6VrORIz.png)