### PR TITLE
Fix utf-8 locale under Ubuntu xenial

### DIFF
--- a/packagingtest/xenial/systemd/Dockerfile
+++ b/packagingtest/xenial/systemd/Dockerfile
@@ -32,6 +32,9 @@ RUN echo -e "#!/bin/sh\nexit 101\n" > /usr/sbin/policy-rc.d && \
     apt-get -y install gdebi-core sshpass cron \
       netcat net-tools
 
+ENV LANG en_US.UTF-8
+ENV LANGUAGE en_US:en
+ENV LC_ALL en_US.UTF-8
 ENV container docker
 
 RUN find /etc/systemd/system \


### PR DESCRIPTION
Fixes https://github.com/StackStorm/st2-packages/issues/444

![](https://i.imgur.com/Y4zyR5t.png)

Previous try https://github.com/StackStorm/st2-dockerfiles/pull/46 wasn't enough for Xenial to set the correct utf-8 locale.

Merging this PR should regenerate [`packagingtest:xenial`](https://hub.docker.com/r/stackstorm/packagingtest/tags/) docker image.