### PR TITLE
Try to fix Xenial UTF-8 test one more time

### DIFF
--- a/packagingenv/README.md
+++ b/packagingenv/README.md
@@ -1,0 +1,3 @@
+Warning!
+
+`packagingenv` is deprecated in favor of `packagingtest` Docker images.

--- a/packagingtest/xenial/systemd/Dockerfile
+++ b/packagingtest/xenial/systemd/Dockerfile
@@ -24,7 +24,8 @@ RUN sed -ri 's/^session\s+required\s+pam_loginuid.so$/session optional pam_login
 # install locales package and set default locale to 'UTF-8' for the
 # test execution environment
 RUN apt-get -y update && apt-get -y install locales && \
-    echo 'en_US.UTF-8 UTF-8' > /etc/locale.gen && locale-gen
+    echo 'en_US.UTF-8 UTF-8' > /etc/locale.gen && locale-gen && \
+    update-locale LANG=en_US.UTF-8 LC_ALL=en_US.UTF-8
 
 # install core software for packaging and ssh communication
 RUN echo -e "#!/bin/sh\nexit 101\n" > /usr/sbin/policy-rc.d && \
@@ -33,7 +34,6 @@ RUN echo -e "#!/bin/sh\nexit 101\n" > /usr/sbin/policy-rc.d && \
       netcat net-tools
 
 ENV LANG en_US.UTF-8
-ENV LANGUAGE en_US:en
 ENV LC_ALL en_US.UTF-8
 ENV container docker
 

--- a/packagingtest/xenial/systemd/Dockerfile
+++ b/packagingtest/xenial/systemd/Dockerfile
@@ -1,4 +1,8 @@
-FROM buildpack-deps:xenial
+FROM ubuntu:xenial
+
+ENV container docker
+ENV LANG en_US.UTF-8
+ENV LC_ALL en_US.UTF-8
 
 # Enable remote pubkey access
 RUN mkdir /root/.ssh && chmod 700 /root/.ssh && \
@@ -24,18 +28,13 @@ RUN sed -ri 's/^session\s+required\s+pam_loginuid.so$/session optional pam_login
 # install locales package and set default locale to 'UTF-8' for the
 # test execution environment
 RUN apt-get -y update && apt-get -y install locales && \
-    echo 'en_US.UTF-8 UTF-8' > /etc/locale.gen && locale-gen && \
-    update-locale LANG=en_US.UTF-8 LC_ALL=en_US.UTF-8
+    echo 'en_US.UTF-8 UTF-8' > /etc/locale.gen && locale-gen
 
 # install core software for packaging and ssh communication
 RUN echo -e "#!/bin/sh\nexit 101\n" > /usr/sbin/policy-rc.d && \
     DEBIAN_FRONTEND=noninteractive && apt-get -y update && \
     apt-get -y install gdebi-core sshpass cron \
       netcat net-tools
-
-ENV LANG en_US.UTF-8
-ENV LC_ALL en_US.UTF-8
-ENV container docker
 
 RUN find /etc/systemd/system \
          /lib/systemd/system \

--- a/packagingtest/xenial/systemd/Dockerfile
+++ b/packagingtest/xenial/systemd/Dockerfile
@@ -23,7 +23,7 @@ RUN sed -ri 's/^session\s+required\s+pam_loginuid.so$/session optional pam_login
 
 # install locales package and set default locale to 'UTF-8' for the
 # test execution environment
-RUN apt-get -y update && apt-get -y install locales && \
+RUN apt-get -y install locales dbus && touch /etc/default/keyboard \
     echo 'en_US.UTF-8 UTF-8' > /etc/locale.gen && locale-gen && \
     update-locale LANG=en_US.UTF-8 LC_ALL=en_US.UTF-8
 

--- a/packagingtest/xenial/systemd/Dockerfile
+++ b/packagingtest/xenial/systemd/Dockerfile
@@ -1,8 +1,4 @@
-FROM ubuntu:xenial
-
-ENV container docker
-ENV LANG en_US.UTF-8
-ENV LC_ALL en_US.UTF-8
+FROM buildpack-deps:xenial
 
 # Enable remote pubkey access
 RUN mkdir /root/.ssh && chmod 700 /root/.ssh && \
@@ -28,13 +24,18 @@ RUN sed -ri 's/^session\s+required\s+pam_loginuid.so$/session optional pam_login
 # install locales package and set default locale to 'UTF-8' for the
 # test execution environment
 RUN apt-get -y update && apt-get -y install locales && \
-    echo 'en_US.UTF-8 UTF-8' > /etc/locale.gen && locale-gen
+    echo 'en_US.UTF-8 UTF-8' > /etc/locale.gen && locale-gen && \
+    update-locale LANG=en_US.UTF-8 LC_ALL=en_US.UTF-8
 
 # install core software for packaging and ssh communication
 RUN echo -e "#!/bin/sh\nexit 101\n" > /usr/sbin/policy-rc.d && \
     DEBIAN_FRONTEND=noninteractive && apt-get -y update && \
     apt-get -y install gdebi-core sshpass cron \
       netcat net-tools
+
+ENV LANG en_US.UTF-8
+ENV LC_ALL en_US.UTF-8
+ENV container docker
 
 RUN find /etc/systemd/system \
          /lib/systemd/system \

--- a/packagingtest/xenial/systemd/Dockerfile
+++ b/packagingtest/xenial/systemd/Dockerfile
@@ -1,5 +1,11 @@
 FROM buildpack-deps:xenial
 
+ENV container docker
+ENV TERM xterm
+ENV DEBIAN_FRONTEND noninteractive
+
+RUN apt-get -y update
+
 # Enable remote pubkey access
 RUN mkdir /root/.ssh && chmod 700 /root/.ssh && \
     echo "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCdCmmPjsOBWRXc+PKdgDRrsciNjp25zTacyz8Gdkln2ma046brOYXAphhp/85DKgHtANBBt3cl4+HnpDbmAfyq2qZT7hWzAbMxtq0Sj+yyFyUdreXoe4gEKyxpV6o8p/R/XzEcawvqX/vFc5EIFmvTdamxZs9DQmOE5AZMzUB18Kerkrb0/arUcZ8iMi9Ng9a18avow+7oUFZ6Oub7ISz/dkIRojaKO/2paJZ4p+v7ZLn7Hq8TUeBkgAlx872oh8J8linhIq17zK6x4MGL8qiurp2hnfe0cuCxwcsYGy+4DfK51+E2vks6FprCIfF5hIdz26euPn67/YpM0F0b5nXF busybee@drone" >> /root/.ssh/authorized_keys
@@ -8,9 +14,15 @@ RUN mkdir /root/.ssh && chmod 700 /root/.ssh && \
 COPY busybee*  /root/.ssh/
 RUN chmod 600 /root/.ssh/busybee
 
-RUN DEBIAN_FRONTEND=noninteractive && apt-get -y update && \
-    apt-get install -y openssh-server sudo && \
+RUN apt-get install -y openssh-server sudo && \
     mkdir /var/run/sshd
+
+# install locales package and set default locale to 'UTF-8' for the test execution environment
+RUN apt-get -y install locales && \
+    locale-gen en_US.UTF-8 && \
+    dpkg-reconfigure locales && \
+    update-locale LANG=en_US.UTF-8
+ENV LANG en_US.UTF-8
 
 # 1. small fix for SSH in ubuntu 13.10 (that's harmless everywhere else)
 # 2. permit root logins and set simple password password and pubkey
@@ -21,21 +33,9 @@ RUN sed -ri 's/^session\s+required\s+pam_loginuid.so$/session optional pam_login
         sed -ri 's/requiretty/!requiretty/' /etc/sudoers && \
         echo 'root:docker.io' | chpasswd
 
-# install locales package and set default locale to 'UTF-8' for the
-# test execution environment
-RUN apt-get -y install locales dbus && touch /etc/default/keyboard \
-    echo 'en_US.UTF-8 UTF-8' > /etc/locale.gen && locale-gen && \
-    update-locale LANG=en_US.UTF-8 LC_ALL=en_US.UTF-8
-
 # install core software for packaging and ssh communication
 RUN echo -e "#!/bin/sh\nexit 101\n" > /usr/sbin/policy-rc.d && \
-    DEBIAN_FRONTEND=noninteractive && apt-get -y update && \
-    apt-get -y install gdebi-core sshpass cron \
-      netcat net-tools
-
-ENV LANG en_US.UTF-8
-ENV LC_ALL en_US.UTF-8
-ENV container docker
+    apt-get -y install gdebi-core sshpass cron netcat net-tools
 
 RUN find /etc/systemd/system \
          /lib/systemd/system \


### PR DESCRIPTION
Following the previous 2 tries: https://github.com/StackStorm/st2-dockerfiles/pull/52 https://github.com/StackStorm/st2-dockerfiles/pull/46 to fix it.

This fixes the test:
```
Command "st2 run core.local cmd=locale"
    stdout
      should match /UTF-8/
```

but still fails on:
```
  Command "st2 run core.local cmd="echo '¯_(ツ)_/¯'""
    exit_status
      should eq 0
```

![screenshot from 2017-07-07 19-20-15](https://user-images.githubusercontent.com/1533818/27966889-97c38dd6-6349-11e7-930b-ae3f18a38a3b.png)



> Merging this PR should regenerate packagingtest:xenial docker image.