### PR TITLE
Add netbase dependency to Ubuntu docker files

### DIFF
--- a/packagingbuild/Dockerfile.template
+++ b/packagingbuild/Dockerfile.template
@@ -17,7 +17,8 @@ RUN yum -y install \
     git \
     mercurial \
     openssh \
-    subversion
+    subversion \
+    setup
 
 # Build tools
 RUN yum -y install \

--- a/packagingbuild/centos6/Dockerfile
+++ b/packagingbuild/centos6/Dockerfile
@@ -11,7 +11,8 @@ RUN yum -y install \
     git \
     mercurial \
     openssh \
-    subversion
+    subversion \
+    setup
 
 # Build tools
 RUN yum -y install \

--- a/packagingbuild/centos7/Dockerfile
+++ b/packagingbuild/centos7/Dockerfile
@@ -11,7 +11,8 @@ RUN yum -y install \
     git \
     mercurial \
     openssh \
-    subversion
+    subversion \
+    setup
 
 # Build tools
 RUN yum -y install \

--- a/packagingenv/Dockerfile.template
+++ b/packagingenv/Dockerfile.template
@@ -17,7 +17,8 @@ RUN yum -y install \
     git \
     mercurial \
     openssh \
-    subversion
+    subversion \
+    setup
 
 # Build tools
 RUN yum -y install \

--- a/packagingenv/centos6/Dockerfile
+++ b/packagingenv/centos6/Dockerfile
@@ -11,7 +11,8 @@ RUN yum -y install \
     git \
     mercurial \
     openssh \
-    subversion
+    subversion \
+    setup
 
 # Build tools
 RUN yum -y install \

--- a/packagingenv/centos7/Dockerfile
+++ b/packagingenv/centos7/Dockerfile
@@ -11,7 +11,8 @@ RUN yum -y install \
     git \
     mercurial \
     openssh \
-    subversion
+    subversion \
+    setup
 
 # Build tools
 RUN yum -y install \

--- a/packagingenv/trusty/Dockerfile
+++ b/packagingenv/trusty/Dockerfile
@@ -39,8 +39,7 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get update && \
     apt-get -y install build-essential python-dev python
 
 # install netbase package (includes /etc/protocols and other files we rely on)
-RUN DEBIAN_FRONTEND=noninteractive apt-get update && \
-    apt-get -y install netbase
+RUN DEBIAN_FRONTEND=noninteractive apt-get -y install netbase
 
 RUN DEBIAN_FRONTEND=noninteractive apt-get -y install \
         devscripts debhelper dh-make && apt-get clean

--- a/packagingenv/trusty/Dockerfile
+++ b/packagingenv/trusty/Dockerfile
@@ -38,6 +38,9 @@ RUN echo -e "#!/bin/sh\nexit 101\n" > /usr/sbin/policy-rc.d && \
 RUN DEBIAN_FRONTEND=noninteractive apt-get update && \
     apt-get -y install build-essential python-dev python
 
+# install netbase package (includes /etc/protocols and other files we rely on)
+RUN DEBIAN_FRONTEND=noninteractive apt-get update && \
+    apt-get -y install netbase
 
 RUN DEBIAN_FRONTEND=noninteractive apt-get -y install \
         devscripts debhelper dh-make && apt-get clean

--- a/packagingenv/xenial/Dockerfile
+++ b/packagingenv/xenial/Dockerfile
@@ -39,8 +39,7 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get update && \
     apt-get -y install build-essential python-dev python
 
 # install netbase package
-RUN DEBIAN_FRONTEND=noninteractive apt-get update && \
-    apt-get -y install netbase
+RUN DEBIAN_FRONTEND=noninteractive apt-get -y install netbase
 
 RUN DEBIAN_FRONTEND=noninteractive apt-get -y install \
         devscripts debhelper dh-make && apt-get clean

--- a/packagingenv/xenial/Dockerfile
+++ b/packagingenv/xenial/Dockerfile
@@ -38,6 +38,9 @@ RUN echo -e "#!/bin/sh\nexit 101\n" > /usr/sbin/policy-rc.d && \
 RUN DEBIAN_FRONTEND=noninteractive apt-get update && \
     apt-get -y install build-essential python-dev python
 
+# install netbase package
+RUN DEBIAN_FRONTEND=noninteractive apt-get update && \
+    apt-get -y install netbase
 
 RUN DEBIAN_FRONTEND=noninteractive apt-get -y install \
         devscripts debhelper dh-make && apt-get clean

--- a/packagingtest/Dockerfile.common
+++ b/packagingtest/Dockerfile.common
@@ -17,7 +17,8 @@ RUN yum -y install \
     git \
     mercurial \
     openssh \
-    subversion
+    subversion \
+    setup
 
 # Build tools
 RUN yum -y install \

--- a/packagingtest/centos7/systemd/Dockerfile
+++ b/packagingtest/centos7/systemd/Dockerfile
@@ -11,7 +11,8 @@ RUN yum -y install \
     git \
     mercurial \
     openssh \
-    subversion
+    subversion \
+    setup
 
 # Build tools
 RUN yum -y install \

--- a/packagingtest/trusty/upstart/Dockerfile
+++ b/packagingtest/trusty/upstart/Dockerfile
@@ -27,6 +27,10 @@ RUN echo -e "#!/bin/sh\nexit 101\n" > /usr/sbin/policy-rc.d && \
     apt-get -y install gdebi-core sshpass cron \
       netcat net-tools
 
+# install netbase package (includes /etc/protocols and other files we rely on)
+RUN DEBIAN_FRONTEND=noninteractive apt-get update && \
+    apt-get -y install netbase
+
 COPY init-fake.conf /etc/init/fake-container-events.conf
 
 # undo some leet hax of the base image

--- a/packagingtest/trusty/upstart/Dockerfile
+++ b/packagingtest/trusty/upstart/Dockerfile
@@ -28,8 +28,7 @@ RUN echo -e "#!/bin/sh\nexit 101\n" > /usr/sbin/policy-rc.d && \
       netcat net-tools
 
 # install netbase package (includes /etc/protocols and other files we rely on)
-RUN DEBIAN_FRONTEND=noninteractive apt-get update && \
-    apt-get -y install netbase
+RUN DEBIAN_FRONTEND=noninteractive apt-get -y install netbase
 
 COPY init-fake.conf /etc/init/fake-container-events.conf
 

--- a/packagingtest/xenial/systemd/Dockerfile
+++ b/packagingtest/xenial/systemd/Dockerfile
@@ -38,8 +38,7 @@ RUN echo -e "#!/bin/sh\nexit 101\n" > /usr/sbin/policy-rc.d && \
     apt-get -y install gdebi-core sshpass cron netcat net-tools
 
 # install netbase package (includes /etc/protocols and other files we rely on)
-RUN DEBIAN_FRONTEND=noninteractive apt-get update && \
-    apt-get -y install netbase
+RUN DEBIAN_FRONTEND=noninteractive apt-get -y install netbase
 
 RUN find /etc/systemd/system \
          /lib/systemd/system \

--- a/packagingtest/xenial/systemd/Dockerfile
+++ b/packagingtest/xenial/systemd/Dockerfile
@@ -37,6 +37,10 @@ RUN sed -ri 's/^session\s+required\s+pam_loginuid.so$/session optional pam_login
 RUN echo -e "#!/bin/sh\nexit 101\n" > /usr/sbin/policy-rc.d && \
     apt-get -y install gdebi-core sshpass cron netcat net-tools
 
+# install netbase package (includes /etc/protocols and other files we rely on)
+RUN DEBIAN_FRONTEND=noninteractive apt-get update && \
+    apt-get -y install netbase
+
 RUN find /etc/systemd/system \
          /lib/systemd/system \
          -path '*.wants/*' \

--- a/stackstorm/Dockerfile
+++ b/stackstorm/Dockerfile
@@ -8,7 +8,7 @@ LABEL com.stackstorm.version="${ST2_VERSION}"
 
 ADD ./sources.list /etc/apt/ 
 
-RUN apt-get -y update && apt-get -y install adduser procps python2.7 libffi5 libyaml-0-2 git libpcre3 libpython2.7 libxml2 python-dev libssl-dev libffi-dev sudo netbase
+RUN apt-get -y update && apt-get -y install adduser procps python2.7 libffi5 libyaml-0-2 git libpcre3 libpython2.7 libxml2 python-dev libssl-dev libffi-dev sudo
 
 ADD ${ST2_PACKAGE} /tmp/st2_${ST2_VERSION}_amd64.deb
 RUN dpkg -i /tmp/st2_${ST2_VERSION}_amd64.deb && rm -r /tmp/st2_${ST2_VERSION}_amd64.deb && apt-get clean

--- a/stackstorm/Dockerfile
+++ b/stackstorm/Dockerfile
@@ -8,7 +8,7 @@ LABEL com.stackstorm.version="${ST2_VERSION}"
 
 ADD ./sources.list /etc/apt/ 
 
-RUN apt-get -y update && apt-get -y install adduser procps python2.7 libffi5 libyaml-0-2 git libpcre3 libpython2.7 libxml2 python-dev libssl-dev libffi-dev sudo
+RUN apt-get -y update && apt-get -y install adduser procps python2.7 libffi5 libyaml-0-2 git libpcre3 libpython2.7 libxml2 python-dev libssl-dev libffi-dev sudo netbase
 
 ADD ${ST2_PACKAGE} /tmp/st2_${ST2_VERSION}_amd64.deb
 RUN dpkg -i /tmp/st2_${ST2_VERSION}_amd64.deb && rm -r /tmp/st2_${ST2_VERSION}_amd64.deb && apt-get clean


### PR DESCRIPTION
This pull request adds `netbase` package dependency which is required by st2 and it's missing in some base container images.