### PR TITLE
Remove setup package from packagingbuild container Dockerfile

### DIFF
--- a/packagingbuild/Dockerfile.template
+++ b/packagingbuild/Dockerfile.template
@@ -17,8 +17,7 @@ RUN yum -y install \
     git \
     mercurial \
     openssh \
-    subversion \
-    setup
+    subversion
 
 # Build tools
 RUN yum -y install \

--- a/packagingbuild/centos6/Dockerfile
+++ b/packagingbuild/centos6/Dockerfile
@@ -11,8 +11,7 @@ RUN yum -y install \
     git \
     mercurial \
     openssh \
-    subversion \
-    setup
+    subversion
 
 # Build tools
 RUN yum -y install \

--- a/packagingbuild/centos7/Dockerfile
+++ b/packagingbuild/centos7/Dockerfile
@@ -11,8 +11,7 @@ RUN yum -y install \
     git \
     mercurial \
     openssh \
-    subversion \
-    setup
+    subversion
 
 # Build tools
 RUN yum -y install \


### PR DESCRIPTION
Per https://github.com/StackStorm/st2-dockerfiles/pull/56/files/183fbe5f90188c2819885554260ed7d7cd7da06d#r169742776, we only need it in the container used for tests (packagingtest).