### PR TITLE
Fix dh-virtualenv failure, pin virtualenv=15.1.0, pip=9.0.1

### DIFF
--- a/packagingbuild/Dockerfile.debian
+++ b/packagingbuild/Dockerfile.debian
@@ -17,10 +17,9 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get -y install \
           rm -rf /tmp/dh-virtualenv*
 
 # Install fresh pip and co
-# pin pip to 9.0 due to dh-virtualenv incompatibility with 10.0
-RUN curl https://bootstrap.pypa.io/get-pip.py | python - pip==9.0.3 wheel==0.31.0 setuptools==39.0.1; \
-      pip install --upgrade wheel virtualenv \
-      requests[security] && rm -rf /root/.cache
+# pin virtualenv to '15.1.0' (installs pip 9) due to dh-virtualenv incompatibility with pip 10.0
+RUN curl https://bootstrap.pypa.io/get-pip.py | python - virtualenv==15.1.0 pip==9.0.1 wheel==0.29.0 setuptools==28.0.0; \
+      pip install --upgrade requests[security] && rm -rf /root/.cache
 
 {%- if version in ('xenial') %}
 RUN DEBIAN_FRONTEND=noninteractive apt-get -y install dh-systemd && apt-get clean

--- a/packagingbuild/Dockerfile.debian
+++ b/packagingbuild/Dockerfile.debian
@@ -11,13 +11,14 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get -y install \
 RUN DEBIAN_FRONTEND=noninteractive apt-get -y install \
         python-setuptools python-sphinx python-mock python-virtualenv && \
         apt-get clean && \
-        git clone https://github.com/stackstorm/dh-virtualenv.git /tmp/dh-virtualenv && \
+        git clone -b fix/py-custom-shebang https://github.com/stackstorm/dh-virtualenv.git /tmp/dh-virtualenv && \
         cd /tmp/dh-virtualenv && \
         dpkg-buildpackage -b -uc -us && dpkg -i ../dh-virtualenv_*.deb && \
           rm -rf /tmp/dh-virtualenv*
 
 # Install fresh pip and co
-RUN curl https://bootstrap.pypa.io/get-pip.py | python - pip==7.1.2 wheel==0.26.0 setuptools==18.7.1; \
+# pin pip to 9.0 due to dh-virtualenv incompatibility with 10.0
+RUN curl https://bootstrap.pypa.io/get-pip.py | python - pip==9.0.3 wheel==0.31.0 setuptools==39.0.1; \
       pip install --upgrade wheel virtualenv \
       requests[security] && rm -rf /root/.cache
 

--- a/packagingbuild/Dockerfile.template
+++ b/packagingbuild/Dockerfile.template
@@ -110,11 +110,10 @@ RUN wget https://bintray.com/stackstorm/el6/rpm -O /etc/yum.repos.d/stackstorm-e
       yum -y install st2python && rm -rf /tmp/*
 
 # Install fresh pip and co
-# pin pip to 9.0 due to dh-virtualenv incompatibility with 10.0
+# pin virtualenv to '15.1.0' (installs pip 9) due to dh-virtualenv incompatibility with pip 10.0
 RUN PATH=/usr/share/python/st2python/bin:$PATH bash -c \
-      "curl https://bootstrap.pypa.io/get-pip.py | python - pip==9.0.3 wheel==0.31.0 setuptools==39.0.1; \
-        pip install --upgrade virtualenv \
-        requests[security] venvctrl" \
+      "curl https://bootstrap.pypa.io/get-pip.py | python - virtualenv==15.1.0 pip==9.0.1 wheel==0.29.0 setuptools==28.0.0; \
+        pip install --upgrade requests[security] venvctrl" \
     && rm -rf /root/.cache
 
 {%- elif dist in ('centos', 'fedora') -%}
@@ -123,10 +122,9 @@ RUN PATH=/usr/share/python/st2python/bin:$PATH bash -c \
 RUN yum -y install python-devel rpmdevtools
 
 # Install fresh pip and co
-# pin pip to 9.0 due to dh-virtualenv incompatibility with 10.0
-RUN curl https://bootstrap.pypa.io/get-pip.py | python - pip==9.0.3 wheel==0.31.0 setuptools==39.0.1; \
-      pip install --upgrade virtualenv pip==pip==9.0.3 \
-      requests[security] venvctrl && rm -rf /root/.cache
+# pin virtualenv to '15.1.0' (installs pip 9) due to dh-virtualenv incompatibility with pip 10.0
+RUN curl https://bootstrap.pypa.io/get-pip.py | python - virtualenv==15.1.0 pip==9.0.1 wheel==0.29.0 setuptools==28.0.0; \
+      pip install --upgrade requests[security] venvctrl && rm -rf /root/.cache
 
 {%- else -%}
 {% include "Dockerfile.debian" -%}

--- a/packagingbuild/Dockerfile.template
+++ b/packagingbuild/Dockerfile.template
@@ -110,8 +110,9 @@ RUN wget https://bintray.com/stackstorm/el6/rpm -O /etc/yum.repos.d/stackstorm-e
       yum -y install st2python && rm -rf /tmp/*
 
 # Install fresh pip and co
+# pin pip to 9.0 due to dh-virtualenv incompatibility with 10.0
 RUN PATH=/usr/share/python/st2python/bin:$PATH bash -c \
-      "curl https://bootstrap.pypa.io/get-pip.py | python - pip==7.1.2 wheel==0.26.0 setuptools==18.7.1; \
+      "curl https://bootstrap.pypa.io/get-pip.py | python - pip==9.0.3 wheel==0.31.0 setuptools==39.0.1; \
         pip install --upgrade virtualenv \
         requests[security] venvctrl" \
     && rm -rf /root/.cache
@@ -122,8 +123,9 @@ RUN PATH=/usr/share/python/st2python/bin:$PATH bash -c \
 RUN yum -y install python-devel rpmdevtools
 
 # Install fresh pip and co
-RUN curl https://bootstrap.pypa.io/get-pip.py | python - pip==7.1.2 wheel==0.26.0 setuptools==18.7.1; \
-      pip install --upgrade virtualenv pip==7.1.2 \
+# pin pip to 9.0 due to dh-virtualenv incompatibility with 10.0
+RUN curl https://bootstrap.pypa.io/get-pip.py | python - pip==9.0.3 wheel==0.31.0 setuptools==39.0.1; \
+      pip install --upgrade virtualenv pip==pip==9.0.3 \
       requests[security] venvctrl && rm -rf /root/.cache
 
 {%- else -%}

--- a/packagingbuild/centos6/Dockerfile
+++ b/packagingbuild/centos6/Dockerfile
@@ -87,11 +87,10 @@ RUN wget https://bintray.com/stackstorm/el6/rpm -O /etc/yum.repos.d/stackstorm-e
       yum -y install st2python && rm -rf /tmp/*
 
 # Install fresh pip and co
-# pin pip to 9.0 due to dh-virtualenv incompatibility with 10.0
+# pin virtualenv to '15.1.0' (installs pip 9) due to dh-virtualenv incompatibility with pip 10.0
 RUN PATH=/usr/share/python/st2python/bin:$PATH bash -c \
-      "curl https://bootstrap.pypa.io/get-pip.py | python - pip==9.0.3 wheel==0.31.0 setuptools==39.0.1; \
-        pip install --upgrade virtualenv \
-        requests[security] venvctrl" \
+      "curl https://bootstrap.pypa.io/get-pip.py | python - virtualenv==15.1.0 pip==9.0.1 wheel==0.29.0 setuptools==28.0.0; \
+        pip install --upgrade requests[security] venvctrl" \
     && rm -rf /root/.cache
 
 VOLUME ['/home/busybee/build']

--- a/packagingbuild/centos6/Dockerfile
+++ b/packagingbuild/centos6/Dockerfile
@@ -87,8 +87,9 @@ RUN wget https://bintray.com/stackstorm/el6/rpm -O /etc/yum.repos.d/stackstorm-e
       yum -y install st2python && rm -rf /tmp/*
 
 # Install fresh pip and co
+# pin pip to 9.0 due to dh-virtualenv incompatibility with 10.0
 RUN PATH=/usr/share/python/st2python/bin:$PATH bash -c \
-      "curl https://bootstrap.pypa.io/get-pip.py | python - pip==10.0.0 wheel==0.31.0 setuptools==39.0.1; \
+      "curl https://bootstrap.pypa.io/get-pip.py | python - pip==9.0.3 wheel==0.31.0 setuptools==39.0.1; \
         pip install --upgrade virtualenv \
         requests[security] venvctrl" \
     && rm -rf /root/.cache

--- a/packagingbuild/centos7/Dockerfile
+++ b/packagingbuild/centos7/Dockerfile
@@ -83,8 +83,9 @@ RUN yum -y install nc net-tools
 RUN yum -y install python-devel rpmdevtools
 
 # Install fresh pip and co
-RUN curl https://bootstrap.pypa.io/get-pip.py | python - pip==10.0.0 wheel==0.31.0 setuptools==39.0.1; \
-      pip install --upgrade virtualenv pip==10.0.0 \
+# pin pip to 9.0 due to dh-virtualenv incompatibility with 10.0
+RUN curl https://bootstrap.pypa.io/get-pip.py | python - pip==9.0.3 wheel==0.31.0 setuptools==39.0.1; \
+      pip install --upgrade virtualenv pip==9.0.3 \
       requests[security] venvctrl && rm -rf /root/.cache
 
 VOLUME ['/home/busybee/build']

--- a/packagingbuild/centos7/Dockerfile
+++ b/packagingbuild/centos7/Dockerfile
@@ -83,10 +83,9 @@ RUN yum -y install nc net-tools
 RUN yum -y install python-devel rpmdevtools
 
 # Install fresh pip and co
-# pin pip to 9.0 due to dh-virtualenv incompatibility with 10.0
-RUN curl https://bootstrap.pypa.io/get-pip.py | python - pip==9.0.3 wheel==0.31.0 setuptools==39.0.1; \
-      pip install --upgrade virtualenv pip==9.0.3 \
-      requests[security] venvctrl && rm -rf /root/.cache
+# pin virtualenv to '15.1.0' (installs pip 9) due to dh-virtualenv incompatibility with pip 10.0
+RUN curl https://bootstrap.pypa.io/get-pip.py | python - virtualenv==15.1.0 pip==9.0.1 wheel==0.29.0 setuptools==28.0.0; \
+      pip install --upgrade requests[security] venvctrl && rm -rf /root/.cache
 
 VOLUME ['/home/busybee/build']
 EXPOSE 22

--- a/packagingbuild/trusty/Dockerfile
+++ b/packagingbuild/trusty/Dockerfile
@@ -52,10 +52,9 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get -y install \
           rm -rf /tmp/dh-virtualenv*
 
 # Install fresh pip and co
-# pin pip to 9.0 due to dh-virtualenv incompatibility with 10.0
-RUN curl https://bootstrap.pypa.io/get-pip.py | python - pip==9.0.3 wheel==0.31.0 setuptools==39.0.1; \
-      pip install --upgrade wheel virtualenv \
-      requests[security] && rm -rf /root/.cache
+# pin virtualenv to '15.1.0' (installs pip 9) due to dh-virtualenv incompatibility with pip 10.0
+RUN curl https://bootstrap.pypa.io/get-pip.py | python - virtualenv==15.1.0 pip==9.0.1 wheel==0.29.0 setuptools==28.0.0; \
+      pip install --upgrade requests[security] && rm -rf /root/.cache
 
 VOLUME ['/home/busybee/build']
 EXPOSE 22

--- a/packagingbuild/trusty/Dockerfile
+++ b/packagingbuild/trusty/Dockerfile
@@ -46,13 +46,14 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get -y install \
 RUN DEBIAN_FRONTEND=noninteractive apt-get -y install \
         python-setuptools python-sphinx python-mock python-virtualenv && \
         apt-get clean && \
-        git clone https://github.com/stackstorm/dh-virtualenv.git /tmp/dh-virtualenv && \
+        git clone -b fix/py-custom-shebang https://github.com/stackstorm/dh-virtualenv.git /tmp/dh-virtualenv && \
         cd /tmp/dh-virtualenv && \
         dpkg-buildpackage -b -uc -us && dpkg -i ../dh-virtualenv_*.deb && \
           rm -rf /tmp/dh-virtualenv*
 
 # Install fresh pip and co
-RUN curl https://bootstrap.pypa.io/get-pip.py | python - pip==10.0.0 wheel==0.31.0 setuptools==39.0.1; \
+# pin pip to 9.0 due to dh-virtualenv incompatibility with 10.0
+RUN curl https://bootstrap.pypa.io/get-pip.py | python - pip==9.0.3 wheel==0.31.0 setuptools==39.0.1; \
       pip install --upgrade wheel virtualenv \
       requests[security] && rm -rf /root/.cache
 

--- a/packagingbuild/xenial/Dockerfile
+++ b/packagingbuild/xenial/Dockerfile
@@ -52,10 +52,9 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get -y install \
           rm -rf /tmp/dh-virtualenv*
 
 # Install fresh pip and co
-# pin pip to 9.0 due to dh-virtualenv incompatibility with 10.0
-RUN curl https://bootstrap.pypa.io/get-pip.py | python - pip==9.0.3 wheel==0.31.0 setuptools==39.0.1; \
-      pip install --upgrade wheel virtualenv \
-      requests[security] && rm -rf /root/.cache
+# pin virtualenv to '15.1.0' (installs pip 9) due to dh-virtualenv incompatibility with pip 10.0
+RUN curl https://bootstrap.pypa.io/get-pip.py | python - virtualenv==15.1.0 pip==9.0.1 wheel==0.29.0 setuptools==28.0.0; \
+      pip install --upgrade requests[security] && rm -rf /root/.cache
 RUN DEBIAN_FRONTEND=noninteractive apt-get -y install dh-systemd && apt-get clean
 
 VOLUME ['/home/busybee/build']

--- a/packagingbuild/xenial/Dockerfile
+++ b/packagingbuild/xenial/Dockerfile
@@ -46,13 +46,14 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get -y install \
 RUN DEBIAN_FRONTEND=noninteractive apt-get -y install \
         python-setuptools python-sphinx python-mock python-virtualenv && \
         apt-get clean && \
-        git clone https://github.com/stackstorm/dh-virtualenv.git /tmp/dh-virtualenv && \
+        git clone -b fix/py-custom-shebang https://github.com/stackstorm/dh-virtualenv.git /tmp/dh-virtualenv && \
         cd /tmp/dh-virtualenv && \
         dpkg-buildpackage -b -uc -us && dpkg -i ../dh-virtualenv_*.deb && \
           rm -rf /tmp/dh-virtualenv*
 
 # Install fresh pip and co
-RUN curl https://bootstrap.pypa.io/get-pip.py | python - pip==10.0.0 wheel==0.31.0 setuptools==39.0.1; \
+# pin pip to 9.0 due to dh-virtualenv incompatibility with 10.0
+RUN curl https://bootstrap.pypa.io/get-pip.py | python - pip==9.0.3 wheel==0.31.0 setuptools==39.0.1; \
       pip install --upgrade wheel virtualenv \
       requests[security] && rm -rf /root/.cache
 RUN DEBIAN_FRONTEND=noninteractive apt-get -y install dh-systemd && apt-get clean


### PR DESCRIPTION
Avoid `pip 10`, pin `virtualenv=15.1.0` which ships `with pip=9.0.1`.

Using latest pip 10 breaks `dh-virtualenv` packaging builds in CircleCI.

See previous tries: 
https://github.com/StackStorm/st2-dockerfiles/pull/58
https://github.com/StackStorm/st2-dockerfiles/pull/59

