### PR TITLE
Use dh-virtualenv from "stackstorm_patched" branch in our fork

### DIFF
--- a/packagingbuild/Dockerfile.debian
+++ b/packagingbuild/Dockerfile.debian
@@ -11,7 +11,7 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get -y install \
 RUN DEBIAN_FRONTEND=noninteractive apt-get -y install \
         python-setuptools python-sphinx python-mock python-virtualenv && \
         apt-get clean && \
-        git clone -b fix/py-custom-shebang https://github.com/stackstorm/dh-virtualenv.git /tmp/dh-virtualenv && \
+        git clone -b stackstorm_patched https://github.com/stackstorm/dh-virtualenv.git /tmp/dh-virtualenv && \
         cd /tmp/dh-virtualenv && \
         dpkg-buildpackage -b -uc -us && dpkg -i ../dh-virtualenv_*.deb && \
           rm -rf /tmp/dh-virtualenv*

--- a/packagingbuild/trusty/Dockerfile
+++ b/packagingbuild/trusty/Dockerfile
@@ -46,7 +46,7 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get -y install \
 RUN DEBIAN_FRONTEND=noninteractive apt-get -y install \
         python-setuptools python-sphinx python-mock python-virtualenv && \
         apt-get clean && \
-        git clone -b fix/py-custom-shebang https://github.com/stackstorm/dh-virtualenv.git /tmp/dh-virtualenv && \
+        git clone -b stackstorm_patched https://github.com/stackstorm/dh-virtualenv.git /tmp/dh-virtualenv && \
         cd /tmp/dh-virtualenv && \
         dpkg-buildpackage -b -uc -us && dpkg -i ../dh-virtualenv_*.deb && \
           rm -rf /tmp/dh-virtualenv*

--- a/packagingbuild/xenial/Dockerfile
+++ b/packagingbuild/xenial/Dockerfile
@@ -46,7 +46,7 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get -y install \
 RUN DEBIAN_FRONTEND=noninteractive apt-get -y install \
         python-setuptools python-sphinx python-mock python-virtualenv && \
         apt-get clean && \
-        git clone -b fix/py-custom-shebang https://github.com/stackstorm/dh-virtualenv.git /tmp/dh-virtualenv && \
+        git clone -b stackstorm_patched https://github.com/stackstorm/dh-virtualenv.git /tmp/dh-virtualenv && \
         cd /tmp/dh-virtualenv && \
         dpkg-buildpackage -b -uc -us && dpkg -i ../dh-virtualenv_*.deb && \
           rm -rf /tmp/dh-virtualenv*


### PR DESCRIPTION
This pull request updates our Docker images to use dh-virtualenv from "stackstorm_patched" branch in our fork.

We use that branch name notation in other repos where we sadly need to maintain forks so we should also use it here.

This branch was just synced with latest dh-virtualenv upstream (we need this change to be able to use a workaround for latest pip version related issues - https://github.com/spotify/dh-virtualenv/issues/175).

In addition to that, our change / patch was applied on top - https://github.com/StackStorm/dh-virtualenv/commit/340be0ec851953532a620959678a440575982806. I couldn't directly cherry pick Denis' change because code has diverged since then. I did test my change though and confirmed it works as it should.

I don't actually know why we need that change (why do we have script files with `!python` as a shebang), but I will leave that as it is for now.