### PR TITLE
dh-virtualenv requires on 'python-virtualenv' package explicitly

### DIFF
--- a/packagingbuild/Dockerfile.debian
+++ b/packagingbuild/Dockerfile.debian
@@ -1,7 +1,7 @@
 
 # install python development
 RUN DEBIAN_FRONTEND=noninteractive apt-get update && \
-    apt-get -y install build-essential python-dev python
+    apt-get -y install build-essential python-dev python python-virtualenv
 
 
 RUN DEBIAN_FRONTEND=noninteractive apt-get -y install \

--- a/packagingbuild/trusty/Dockerfile
+++ b/packagingbuild/trusty/Dockerfile
@@ -36,7 +36,7 @@ RUN echo -e "#!/bin/sh\nexit 101\n" > /usr/sbin/policy-rc.d && \
 
 # install python development
 RUN DEBIAN_FRONTEND=noninteractive apt-get update && \
-    apt-get -y install build-essential python-dev python
+    apt-get -y install build-essential python-dev python python-virtualenv
 
 
 RUN DEBIAN_FRONTEND=noninteractive apt-get -y install \

--- a/packagingbuild/xenial/Dockerfile
+++ b/packagingbuild/xenial/Dockerfile
@@ -36,7 +36,7 @@ RUN echo -e "#!/bin/sh\nexit 101\n" > /usr/sbin/policy-rc.d && \
 
 # install python development
 RUN DEBIAN_FRONTEND=noninteractive apt-get update && \
-    apt-get -y install build-essential python-dev python
+    apt-get -y install build-essential python-dev python python-virtualenv
 
 
 RUN DEBIAN_FRONTEND=noninteractive apt-get -y install \


### PR DESCRIPTION
pip 'python-virtualenv' is not enough, we'll need also `python-virtualenv` deb package explicitly to make the `dh-virtualenv` build happy.


Part of the story: #58, #59, #60, #61, #62 and https://github.com/StackStorm/st2-packages/pull/549 :smiley: 