### PR TITLE
Fix trusty Docker build, remove all sphinx deps, ship dh-virtualenv fork with no docs

### DIFF
--- a/packagingbuild/Dockerfile.debian
+++ b/packagingbuild/Dockerfile.debian
@@ -10,11 +10,11 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get -y install \
 # Install fresh pip and co
 # pin virtualenv to '15.1.0' (installs pip 9) due to dh-virtualenv incompatibility with pip 10.0
 RUN curl https://bootstrap.pypa.io/get-pip.py | python - virtualenv==15.1.0 pip==9.0.1 wheel==0.29.0 setuptools==28.0.0; \
-      pip install --upgrade requests[security] sphinx_rtd_theme && rm -rf /root/.cache
+      pip install --upgrade requests[security] && rm -rf /root/.cache
 
 # We use our dh-virtualenv version, since it fixes shebangd lines rewrites
 RUN DEBIAN_FRONTEND=noninteractive apt-get -y install \
-        python-setuptools python-sphinx python-mock && \
+        python-setuptools python-mock && \
         apt-get clean && \
         git clone -b stackstorm_patched https://github.com/stackstorm/dh-virtualenv.git /tmp/dh-virtualenv && \
         cd /tmp/dh-virtualenv && \

--- a/packagingbuild/trusty/Dockerfile
+++ b/packagingbuild/trusty/Dockerfile
@@ -45,11 +45,11 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get -y install \
 # Install fresh pip and co
 # pin virtualenv to '15.1.0' (installs pip 9) due to dh-virtualenv incompatibility with pip 10.0
 RUN curl https://bootstrap.pypa.io/get-pip.py | python - virtualenv==15.1.0 pip==9.0.1 wheel==0.29.0 setuptools==28.0.0; \
-      pip install --upgrade requests[security] sphinx_rtd_theme && rm -rf /root/.cache
+      pip install --upgrade requests[security] && rm -rf /root/.cache
 
 # We use our dh-virtualenv version, since it fixes shebangd lines rewrites
 RUN DEBIAN_FRONTEND=noninteractive apt-get -y install \
-        python-setuptools python-sphinx python-mock && \
+        python-setuptools python-mock && \
         apt-get clean && \
         git clone -b stackstorm_patched https://github.com/stackstorm/dh-virtualenv.git /tmp/dh-virtualenv && \
         cd /tmp/dh-virtualenv && \

--- a/packagingbuild/xenial/Dockerfile
+++ b/packagingbuild/xenial/Dockerfile
@@ -45,11 +45,11 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get -y install \
 # Install fresh pip and co
 # pin virtualenv to '15.1.0' (installs pip 9) due to dh-virtualenv incompatibility with pip 10.0
 RUN curl https://bootstrap.pypa.io/get-pip.py | python - virtualenv==15.1.0 pip==9.0.1 wheel==0.29.0 setuptools==28.0.0; \
-      pip install --upgrade requests[security] sphinx_rtd_theme && rm -rf /root/.cache
+      pip install --upgrade requests[security] && rm -rf /root/.cache
 
 # We use our dh-virtualenv version, since it fixes shebangd lines rewrites
 RUN DEBIAN_FRONTEND=noninteractive apt-get -y install \
-        python-setuptools python-sphinx python-mock && \
+        python-setuptools python-mock && \
         apt-get clean && \
         git clone -b stackstorm_patched https://github.com/stackstorm/dh-virtualenv.git /tmp/dh-virtualenv && \
         cd /tmp/dh-virtualenv && \


### PR DESCRIPTION
dh-virtualenv is failing to build under `trusty` due to inexistent package dependencies and outdated versions. Installing `pip` alternatives didnt work.
As a workaround we patch dh-virtualenv to remove 'build docs' stage relying on sphinx so it ships without docs.
See https://github.com/StackStorm/dh-virtualenv/commit/bab5d2ef8c9402c3d203bfb3bf757b39a22e1f1d

---

Part of the story: #58, #59, #60, #61, #62, #63 and https://github.com/StackStorm/st2-packages/pull/549 :smiley: 