### PR TITLE
Pin pip to 9.x.y in Docker images

### DIFF
--- a/buildpack/centos6/Dockerfile
+++ b/buildpack/centos6/Dockerfile
@@ -49,6 +49,7 @@ RUN wget https://bintray.com/stackstorm/el6/rpm -O /etc/yum.repos.d/stackstorm-e
 
 ENV PATH=/usr/share/python/st2python/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 RUN wget -qO - https://bootstrap.pypa.io/get-pip.py | python && \
+    pip install --upgrade "pip>=9.0.0,<10.0.0" && \
     pip install setuptools virtualenv && \
     rm -rf /root/.cache
 

--- a/buildpack/centos7/Dockerfile
+++ b/buildpack/centos7/Dockerfile
@@ -45,6 +45,7 @@ RUN yum -y install \
 # Python and tools
 RUN yum -y install python-devel && \
     wget -qO - https://bootstrap.pypa.io/get-pip.py | python && \
+    pip install --upgrade "pip>=9.0.0,<10.0.0" && \
     pip install setuptools virtualenv && \
     rm -rf /root/.cache
 

--- a/buildpack/trusty/Dockerfile
+++ b/buildpack/trusty/Dockerfile
@@ -4,6 +4,7 @@ RUN apt-get update -y
 # Install python development
 RUN apt-get -y install build-essential python2.7-dev python2.7 && \
     wget -qO - https://bootstrap.pypa.io/get-pip.py | python && \
+    pip install --upgrade "pip>=9.0.0,<10.0.0" && \
     pip install setuptools virtualenv && \
     rm -rf /root/.cache
 


### PR DESCRIPTION
See https://circleci.com/gh/StackStorm/st2-enterprise-auth-backend-ldap/365 to https://circleci.com/gh/StackStorm/st2-enterprise-auth-backend-ldap/368

## pip 10.x
```
(mc-test) lakshmi@Sparkles /Volumes/src.sparse/storm/st2-enterprise-auth-backend-ldap (v2.6_build_test)$ python setup.py --version
('Download pip:\n', 'curl https://bootstrap.pypa.io/get-pip.py | python')
```

## pip 9.x

```
(mc-test) lakshmi@Sparkles /Volumes/src.sparse/storm/st2-enterprise-auth-backend-ldap (v2.6_build_test)$ python setup.py --version
2.6.1
```