### PR TITLE
Add a README for buildpack

### DIFF
--- a/buildpack/README.md
+++ b/buildpack/README.md
@@ -1,0 +1,7 @@
+# Buildpack Dockerfiles
+[![Go to packagingtest Docker Hub](https://img.shields.io/badge/Docker%20Hub-buildpack-blue.svg)](https://hub.docker.com/r/stackstorm/buildpack/)
+
+Docker images with pre-installed requirements to build `.deb` and `.rpm` StackStorm enterprise packages.
+
+NB!
+Images are built automatically on every push to [StackStorm/st2-dockerfiles](https://github.com/StackStorm/st2-dockerfiles/) `master`.


### PR DESCRIPTION
Following the confusion in https://github.com/StackStorm/st2-dockerfiles/pull/65, add a README for `buildpack` stating explicitly that the Dockerfile build is automatic via Docker Hub.

See https://hub.docker.com/r/stackstorm/buildpack/