### PR TITLE
Update Docker Hub badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # st2-dockerfiles
 [![Circle CI](https://circleci.com/gh/StackStorm/st2-dockerfiles.svg?style=shield)](https://circleci.com/gh/StackStorm/workflows/st2-dockerfiles)
-[![Docker Hub](https://img.shields.io/docker/build/stackstorm/st2-dockerfiles.svg)](https://hub.docker.com/r/stackstorm/)
+[![Go to Docker Hub](https://img.shields.io/badge/Docker%20Hub-%E2%86%92-blue.svg)](https://hub.docker.com/r/stackstorm/)
 
 Dockerfiles to build and push StackStorm images to [hub.docker.com/r/stackstorm](https://hub.docker.com/r/stackstorm),
 compatible with K8s Helm chart [stackstorm-ha](https://github.com/StackStorm/stackstorm-ha)


### PR DESCRIPTION
Correct docker hub badge that looks like:

![reponotfound](https://user-images.githubusercontent.com/9972858/46452503-f7975000-c750-11e8-9ee2-2dfc96f62d98.png)

With this PR, it looks like:

![repofound](https://user-images.githubusercontent.com/9972858/46452532-26adc180-c751-11e8-8b98-699928f69234.png)
