### PR TITLE
Don't try to reconnect to st2 DB/MQ on failure and instead exit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,6 @@
 
 # Lock files
 *.lock
+
+# jetBrains IDE
+.idea

--- a/base/files/st2.docker.conf
+++ b/base/files/st2.docker.conf
@@ -4,3 +4,12 @@
 #  `--config-file /etc/st2/st2.conf --config-file /etc/st2/st2.docker.conf --config-file /etc/st2/st2.user.conf`
 # making possible to keep custom st2 config directives in it, instead of modifying the original st2.conf every time.
 # The order of merging: st2.conf < st2.docker.conf < st2.user.conf
+
+[messaging]
+connection_retry_wait = 0
+connection_retries = 0
+
+[database]
+connection_retry_max_delay_m = 0
+connection_retry_backoff_max_s = 0
+connection_retry_backoff_mul = 0

--- a/base/files/st2.docker.conf
+++ b/base/files/st2.docker.conf
@@ -4,12 +4,3 @@
 #  `--config-file /etc/st2/st2.conf --config-file /etc/st2/st2.docker.conf --config-file /etc/st2/st2.user.conf`
 # making possible to keep custom st2 config directives in it, instead of modifying the original st2.conf every time.
 # The order of merging: st2.conf < st2.docker.conf < st2.user.conf
-
-[messaging]
-connection_retry_wait = 0
-connection_retries = 0
-
-[database]
-connection_retry_max_delay_m = 0
-connection_retry_backoff_max_s = 0
-connection_retry_backoff_mul = 0

--- a/base/files/st2.tmp.conf
+++ b/base/files/st2.tmp.conf
@@ -8,3 +8,14 @@ host = 0.0.0.0
 host = 0.0.0.0
 [stream]
 host = 0.0.0.0
+
+# Don't try to reconnect to MQ and exit early and allow k8s to handle reconnection's instead
+[messaging]
+connection_retry_wait = 0
+connection_retries = 0
+
+# Don't try to reconnect to database and exit early and allow k8s to handle reconnection's instead
+[database]
+connection_retry_max_delay_m = 0
+connection_retry_backoff_max_s = 0
+connection_retry_backoff_mul = 0


### PR DESCRIPTION
Add the following entries to the `st2.docker.conf` file so that `st2` does not try to reconnect to the database or RabbitMQ (Fixes: #6).

- `[messaging]`
  - `connection_retry_wait`
  - `connection_retries`
- `[database]`
  - `connection_retry_max_delay_m`
  - `connection_retry_backoff_max_s`
  - `connection_retry_backoff_mul`
