### PR TITLE
Fix Docker layer caching to check the newer image versions to pull

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,7 @@ SHELL := /bin/bash
 .PHONY: build
 build:
 	@docker build \
+		--pull \
 		--build-arg ST2_VERSION=${ST2_VERSION} \
 		-t stackstorm/st2:${DOCKER_TAG} base/
 	@echo -e "\033[32mSuccessfully built \033[1mstackstorm/st2:${DOCKER_TAG}\033[0m\033[32m common Docker image with StackStorm version \033[1m${ST2_VERSION}\033[0m"


### PR DESCRIPTION
A find from https://github.com/StackStorm/st2enterprise-dockerfiles/pull/100

Add `--pull` flag to `docker build` will try to pull the newer images if they exist.
Without this flag build will be based on outdated images as CircleCI caches layers for a long time.
