### PR TITLE
Fix outdated Docker images built due to caching

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,9 @@ jobs:
       - image: docker:18-git
     steps:
       - checkout
-      - setup_remote_docker
+      - setup_remote_docker:
+          # Don't use cache for building Docker images as it introduces more issues
+          docker_layer_caching: false
       - run:
           name: Install Dependencies
           command: apk add make bash

--- a/Makefile
+++ b/Makefile
@@ -7,13 +7,15 @@ SHELL := /bin/bash
 build:
 	@docker build \
 		--pull \
+		--no-cache \
 		--build-arg ST2_VERSION=${ST2_VERSION} \
 		-t stackstorm/st2:${DOCKER_TAG} base/
 	@echo -e "\033[32mSuccessfully built \033[1mstackstorm/st2:${DOCKER_TAG}\033[0m\033[32m common Docker image with StackStorm version \033[1m${ST2_VERSION}\033[0m"
 	@set -e; \
 	for component in st2*; do \
 	  docker build \
-  		--build-arg ST2_VERSION=${ST2_VERSION} \
+	    --no-cache \
+	    --build-arg ST2_VERSION=${ST2_VERSION} \
 	    --tag stackstorm/$$component:${DOCKER_TAG} \
 	    $$component/; \
 	  echo -e "\033[32mSuccessfully built \033[1mstackstorm/$$component:${DOCKER_TAG}\033[0m\033[32m Docker image for StackStorm version \033[1m${ST2_VERSION}\033[0m"; \

--- a/Makefile
+++ b/Makefile
@@ -13,12 +13,12 @@ build:
 	@echo -e "\033[32mSuccessfully built \033[1mstackstorm/st2:${DOCKER_TAG}\033[0m\033[32m common Docker image with StackStorm version \033[1m${ST2_VERSION}\033[0m"
 	@set -e; \
 	for component in st2*; do \
-	  docker build \
-	    --no-cache \
-	    --build-arg ST2_VERSION=${ST2_VERSION} \
-	    --tag stackstorm/$$component:${DOCKER_TAG} \
-	    $$component/; \
-	  echo -e "\033[32mSuccessfully built \033[1mstackstorm/$$component:${DOCKER_TAG}\033[0m\033[32m Docker image for StackStorm version \033[1m${ST2_VERSION}\033[0m"; \
+		docker build \
+			--no-cache \
+			--build-arg ST2_VERSION=${ST2_VERSION} \
+			--tag stackstorm/$$component:${DOCKER_TAG} \
+			$$component/; \
+		echo -e "\033[32mSuccessfully built \033[1mstackstorm/$$component:${DOCKER_TAG}\033[0m\033[32m Docker image for StackStorm version \033[1m${ST2_VERSION}\033[0m"; \
 	done
 
 .PHONY: push


### PR DESCRIPTION
For some reason cache is used during the Docker build:
```
 ---> 1ae966967dc6
Step 17/32 : RUN if [ "${ST2_VERSION#*dev}" != "${ST2_VERSION}" ]; then     ST2_REPO=unstable;   else     ST2_REPO=stable;   fi   && echo ST2_REPO=${ST2_REPO}   && curl -sf https://packagecloud.io/install/repositories/StackStorm/${ST2_REPO}/script.deb.sh | bash   && apt-get install -y st2=${ST2_VERSION}-*   && rm -f /etc/apt/sources.list.d/StackStorm_*.list
 ---> Using cache
```

resulting in outdated images deployed to Hub over and over.

Disable caching alltogether as it's something not critical to this project, including build timing not important.

Also somewhat related to https://github.com/StackStorm/st2-dockerfiles/pull/14