### PR TITLE
Trigger build when git repo tagged

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,7 +39,11 @@ workflows:
   # Build and Push Docker images
   docker-build-push:
     jobs:
-      - docker
+      - docker:
+          filters:
+            tags:
+              only:
+                - /.*/
   # Build and Push nightly 'dev' Docker images from 'master' branch
   nightly-dev-push:
     triggers:


### PR DESCRIPTION
Builds were not triggered when a tag was applied to the `st2-dockerfiles` repo.