### PR TITLE
Remove 'ssl on' directive from nginx patch file

### DIFF
--- a/st2web/files/st2.conf-http.patch
+++ b/st2web/files/st2.conf-http.patch
@@ -29,8 +29,6 @@
 -server {
 -  listen       *:443 ssl;
 -
--  ssl on;
--
 -  ssl_certificate           /etc/ssl/st2/st2.crt;
 -  ssl_certificate_key       /etc/ssl/st2/st2.key;
 -  ssl_session_cache         shared:SSL:10m;

--- a/st2web/files/st2.conf-http.patch
+++ b/st2web/files/st2.conf-http.patch
@@ -9,7 +9,7 @@
  # To enable:
  #    cp ${LOCATION}/st2.conf /etc/nginx/sites-available
  #    ln -l /etc/nginx/sites-available/st2.conf /etc/nginx/sites-enabled/st2.conf
-@@ -9,39 +9,12 @@
+@@ -9,37 +9,12 @@
  server {
    listen *:80 default_server;
  
@@ -49,7 +49,7 @@
  
    location @apiError {
      add_header Content-Type application/json always;
-@@ -53,7 +26,7 @@
+@@ -51,7 +24,7 @@
  
      rewrite ^/api/(.*)  /$1 break;
  
@@ -58,7 +58,7 @@
      proxy_read_timeout    90;
      proxy_connect_timeout 90;
      proxy_redirect        off;
-@@ -83,7 +56,7 @@
+@@ -81,7 +54,7 @@
  
      rewrite ^/stream/(.*)  /$1 break;
  
@@ -67,7 +67,7 @@
      proxy_set_header Host $host;
      proxy_set_header X-Real-IP $remote_addr;
      proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-@@ -111,7 +84,7 @@
+@@ -109,7 +82,7 @@
  
      rewrite ^/auth/(.*)  /$1 break;
  
@@ -76,7 +76,7 @@
      proxy_read_timeout    90;
      proxy_connect_timeout 90;
      proxy_redirect        off;
-@@ -136,4 +109,5 @@
+@@ -134,4 +107,5 @@
      tcp_nopush on;
      tcp_nodelay on;
    }

--- a/st2web/files/st2.conf-https.patch
+++ b/st2web/files/st2.conf-https.patch
@@ -11,7 +11,7 @@
  }
  
  server {
-@@ -37,8 +37,8 @@
+@@ -35,8 +35,8 @@
  
    index  index.html;
  
@@ -22,7 +22,7 @@
  
    add_header              Front-End-Https on;
    add_header              X-Content-Type-Options nosniff;
-@@ -53,7 +53,7 @@
+@@ -51,7 +51,7 @@
  
      rewrite ^/api/(.*)  /$1 break;
  
@@ -31,7 +31,7 @@
      proxy_read_timeout    90;
      proxy_connect_timeout 90;
      proxy_redirect        off;
-@@ -83,7 +83,7 @@
+@@ -81,7 +81,7 @@
  
      rewrite ^/stream/(.*)  /$1 break;
  
@@ -40,7 +40,7 @@
      proxy_set_header Host $host;
      proxy_set_header X-Real-IP $remote_addr;
      proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-@@ -111,7 +111,7 @@
+@@ -109,7 +109,7 @@
  
      rewrite ^/auth/(.*)  /$1 break;
  


### PR DESCRIPTION
Pick up nginx config update following the upstream change https://github.com/StackStorm/st2/pull/4917