### PR TITLE
improved use of docker_tag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,9 +13,11 @@ build:
 	@echo -e "\033[32mSuccessfully built \033[1mstackstorm/st2:${DOCKER_TAG}\033[0m\033[32m common Docker image with StackStorm version \033[1m${ST2_VERSION}\033[0m"
 	@set -e; \
 	for component in st2*; do \
+                echo -e "\033[32mStarting build of \033[1mstackstorm/$$component:${DOCKER_TAG}\033[0m\033[32m Docker image for StackStorm version \033[1m${ST2_VERSION}\033[0m"; \
 		docker build \
 			--no-cache \
 			--build-arg ST2_VERSION=${ST2_VERSION} \
+			--build-arg DOCKER_TAG=${DOCKER_TAG} \
 			--tag stackstorm/$$component:${DOCKER_TAG} \
 			$$component/; \
 		echo -e "\033[32mSuccessfully built \033[1mstackstorm/$$component:${DOCKER_TAG}\033[0m\033[32m Docker image for StackStorm version \033[1m${ST2_VERSION}\033[0m"; \

--- a/st2actionrunner/Dockerfile
+++ b/st2actionrunner/Dockerfile
@@ -1,5 +1,6 @@
 ARG ST2_VERSION
-FROM stackstorm/st2:${ST2_VERSION}
+ARG DOCKER_TAG
+FROM stackstorm/st2:${DOCKER_TAG}
 LABEL com.stackstorm.component="st2actionrunner"
 
 # Install utils used by st2 'linux' pack, part of StackStorm core

--- a/st2api/Dockerfile
+++ b/st2api/Dockerfile
@@ -1,5 +1,6 @@
 ARG ST2_VERSION
-FROM stackstorm/st2:${ST2_VERSION}
+ARG DOCKER_TAG
+FROM stackstorm/st2:${DOCKER_TAG}
 LABEL com.stackstorm.component="st2api"
 
 USER st2

--- a/st2auth/Dockerfile
+++ b/st2auth/Dockerfile
@@ -1,5 +1,6 @@
 ARG ST2_VERSION
-FROM stackstorm/st2:${ST2_VERSION}
+ARG DOCKER_TAG
+FROM stackstorm/st2:${DOCKER_TAG}
 LABEL com.stackstorm.component="st2auth"
 
 USER st2

--- a/st2garbagecollector/Dockerfile
+++ b/st2garbagecollector/Dockerfile
@@ -1,5 +1,6 @@
 ARG ST2_VERSION
-FROM stackstorm/st2:${ST2_VERSION}
+ARG DOCKER_TAG
+FROM stackstorm/st2:${DOCKER_TAG}
 LABEL com.stackstorm.component="st2garbagecollector"
 
 USER st2

--- a/st2notifier/Dockerfile
+++ b/st2notifier/Dockerfile
@@ -1,5 +1,6 @@
 ARG ST2_VERSION
-FROM stackstorm/st2:${ST2_VERSION}
+ARG DOCKER_TAG
+FROM stackstorm/st2:${DOCKER_TAG}
 LABEL com.stackstorm.component="st2notifier"
 
 USER st2

--- a/st2resultstracker/Dockerfile
+++ b/st2resultstracker/Dockerfile
@@ -1,5 +1,6 @@
 ARG ST2_VERSION
-FROM stackstorm/st2:${ST2_VERSION}
+ARG DOCKER_TAG
+FROM stackstorm/st2:${DOCKER_TAG}
 LABEL com.stackstorm.component="st2resultstracker"
 
 USER st2

--- a/st2rulesengine/Dockerfile
+++ b/st2rulesengine/Dockerfile
@@ -1,5 +1,6 @@
 ARG ST2_VERSION
-FROM stackstorm/st2:${ST2_VERSION}
+ARG DOCKER_TAG
+FROM stackstorm/st2:${DOCKER_TAG}
 LABEL com.stackstorm.component="st2rulesengine"
 
 USER st2

--- a/st2scheduler/Dockerfile
+++ b/st2scheduler/Dockerfile
@@ -1,5 +1,6 @@
 ARG ST2_VERSION
-FROM stackstorm/st2:${ST2_VERSION}
+ARG DOCKER_TAG
+FROM stackstorm/st2:${DOCKER_TAG}
 LABEL com.stackstorm.component="st2scheduler"
 
 USER st2

--- a/st2sensorcontainer/Dockerfile
+++ b/st2sensorcontainer/Dockerfile
@@ -1,5 +1,6 @@
 ARG ST2_VERSION
-FROM stackstorm/st2:${ST2_VERSION}
+ARG DOCKER_TAG
+FROM stackstorm/st2:${DOCKER_TAG}
 LABEL com.stackstorm.component="st2sensorcontainer"
 
 USER st2

--- a/st2stream/Dockerfile
+++ b/st2stream/Dockerfile
@@ -1,5 +1,6 @@
 ARG ST2_VERSION
-FROM stackstorm/st2:${ST2_VERSION}
+ARG DOCKER_TAG
+FROM stackstorm/st2:${DOCKER_TAG}
 LABEL com.stackstorm.component="st2stream"
 
 USER st2

--- a/st2timersengine/Dockerfile
+++ b/st2timersengine/Dockerfile
@@ -1,5 +1,6 @@
 ARG ST2_VERSION
-FROM stackstorm/st2:${ST2_VERSION}
+ARG DOCKER_TAG
+FROM stackstorm/st2:${DOCKER_TAG}
 LABEL com.stackstorm.component="st2timersengine"
 
 USER st2

--- a/st2workflowengine/Dockerfile
+++ b/st2workflowengine/Dockerfile
@@ -1,5 +1,6 @@
 ARG ST2_VERSION
-FROM stackstorm/st2:${ST2_VERSION}
+ARG DOCKER_TAG
+FROM stackstorm/st2:${DOCKER_TAG}
 LABEL com.stackstorm.component="st2workflowengine"
 
 USER st2


### PR DESCRIPTION
This change allows the components to use the actual base image you build during a make build. Resolves #26.

Also, added a "Starting build" line to the Makefile to make it easier to see determine which component is currently being built.