### PR TITLE
Remove st2resultstracker and Enterprise mentions

### DIFF
--- a/base/files/.welcome.sh
+++ b/base/files/.welcome.sh
@@ -7,7 +7,6 @@ printf "Welcome to \033[1;38;5;208mStackStorm HA\033[0m \033[1m%s\033[0m (${UBUN
 printf " * Documentation: https://docs.stackstorm.com/\n"
 printf " * Community: https://stackstorm.com/community-signup\n"
 printf " * Forum: https://forum.stackstorm.com/\n"
-printf " * \033[1;38;5;93mEnterprise: https://stackstorm.com/#product\033[0m\n\n"
 # User logged into st2client container
 if [ -n "$ST2CLIENT" ]; then
   printf " Here you can use StackStorm CLI. Examples:\n"

--- a/base/files/.welcome.sh
+++ b/base/files/.welcome.sh
@@ -6,7 +6,7 @@ UBUNTU_VERSION=$(lsb_release -s -d)
 printf "Welcome to \033[1;38;5;208mStackStorm HA\033[0m \033[1m%s\033[0m (${UBUNTU_VERSION} %s %s)\n" "v${ST2_VERSION}" "$(uname -o)" "$(uname -m)"
 printf " * Documentation: https://docs.stackstorm.com/\n"
 printf " * Community: https://stackstorm.com/community-signup\n"
-printf " * Forum: https://forum.stackstorm.com/\n"
+printf " * Forum: https://forum.stackstorm.com/\n\n"
 # User logged into st2client container
 if [ -n "$ST2CLIENT" ]; then
   printf " Here you can use StackStorm CLI. Examples:\n"

--- a/st2resultstracker/Dockerfile
+++ b/st2resultstracker/Dockerfile
@@ -1,7 +1,0 @@
-ARG ST2_VERSION
-FROM stackstorm/st2:${ST2_VERSION}
-LABEL com.stackstorm.component="st2resultstracker"
-
-USER st2
-
-CMD ["/opt/stackstorm/st2/bin/st2resultstracker", "--config-file=/etc/st2/st2.conf", "--config-file=/etc/st2/st2.docker.conf", "--config-file=/etc/st2/st2.user.conf"]


### PR DESCRIPTION
This PR removes the st2resultstracker container and EWC/Enterprise is no longer mentioned on the welcome banner. 

I hope it's ok to address both issues due to the small changes in a single PR.

close #39 
close #32 