### PR TITLE
Improve error handling when building / pushing images

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -95,7 +95,7 @@ endif
 
 verify_tag_update_flag:
 ifeq ($(RELEASE_VERSION), true)
-ifneq ($(shell echo "${TAG_UPDATE_FLAG}" | grep -vE "^[1-3]"),)
+ifneq ($(shell echo "${TAG_UPDATE_FLAG}" | grep -vE "^[0-3]"),)
 	@echo -e "Failed to identify the tags to be set."
 	@echo -e "\033[31mNo images were tagged due to an error when determining the correct tags: ${TAG_UPDATE_FLAG}\033[0m"
 	exit 1

--- a/Makefile
+++ b/Makefile
@@ -95,7 +95,7 @@ endif
 
 verify_tag_update_flag:
 ifeq ($(RELEASE_VERSION), true)
-ifneq ($(shell echo "${TAG_UPDATE_FLAG}" | grep -E "Error:"),)
+ifneq ($(shell echo "${TAG_UPDATE_FLAG}" | grep -vE "^[1-3]"),)
 	@echo -e "Failed to identify the tags to be set."
 	@echo -e "\033[31mNo images were tagged due to an error when determining the correct tags: ${TAG_UPDATE_FLAG}\033[0m"
 	exit 1

--- a/determine_needed_tags.sh
+++ b/determine_needed_tags.sh
@@ -1,5 +1,9 @@
 #!/usr/bin/env bash
 
+# See showHelp() for the supported output values if everything goes fine.
+# $(make) will handle any other output as unexpected and assume an error.
+# Use this to raise error and cause the CI to fail.
+
 # the first argument must be the name of the container, i.e. st2, st2actionrunner, st2stream
 component=$1
 # the 2nd argument is the version of the current build and expects at least major.miinor to be provided


### PR DESCRIPTION
This PR contains a small improvement to the error handling and does no longer rely on a fix string to identify errors. Instead any output that does not match the supported values 0, 1, 2 or 3 will be handled as exception and cause the make command to fail. 

!close https://github.com/StackStorm/st2-dockerfiles/issues/43 