### PR TITLE
adding xmlsec1 to auth dependenci

### DIFF
--- a/st2auth/Dockerfile
+++ b/st2auth/Dockerfile
@@ -2,6 +2,9 @@ ARG ST2_VERSION
 FROM stackstorm/st2:${ST2_VERSION}
 LABEL com.stackstorm.component="st2auth"
 
+
+RUN apt-get install -y xmlsec1
+
 USER st2
 
 VOLUME ["/etc/st2/keys", "/opt/stackstorm/rbac"]


### PR DESCRIPTION
We need xmlsec1 to run pysaml2 on the auth backend, so adding this to st2auth since that's where the sso backend runs