### PR TITLE
Update docker files to follow solar lint rules

### DIFF
--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -58,7 +58,7 @@ COPY files/st2.user.conf /etc/st2/
 COPY files/st2ctl /etc/default/
 
 # Use custom logging config that'll stream all st2 service logs to stdout and never save to files
-RUN cd /etc/st2; \
+WORKDIR /etc/st2; \
   for file in /etc/st2/logging.*.conf; do \
     rm -f ${file}; \
     ln -s logging.docker.conf ${file}; \

--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -71,7 +71,9 @@ RUN apt-get install -y crudini \
   && crudini --merge /etc/st2/st2.conf < /tmp/st2.tmp.conf \
   && rm -f /tmp/st2.tmp.conf \
   && apt-get purge -y crudini \
-  && apt-get autoremove -y
+  && apt-get autoremove -y \
+  && rm -rf /var/lib/apt/lists/* /var/cache/apt/archives/* \
+  && apt-get clean
 
 # Add Custom "StackStorm" welcome message
 COPY files/.welcome.sh /etc/skel/.welcome

--- a/st2actionrunner/Dockerfile
+++ b/st2actionrunner/Dockerfile
@@ -8,8 +8,8 @@ RUN apt-get install -y rsync \
   net-tools \
   dnsutils \
   sendmail \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/archives/* \
-    && apt-get clean
+  && rm -rf /var/lib/apt/lists/* /var/cache/apt/archives/* \
+  && apt-get clean
 
 USER root
 

--- a/st2actionrunner/Dockerfile
+++ b/st2actionrunner/Dockerfile
@@ -7,7 +7,9 @@ RUN apt-get install -y rsync \
   inetutils-traceroute \
   net-tools \
   dnsutils \
-  sendmail
+  sendmail \
+    && rm -rf /var/lib/apt/lists/* /var/cache/apt/archives/* \
+    && apt-get clean
 
 USER root
 

--- a/st2actionrunner/Dockerfile
+++ b/st2actionrunner/Dockerfile
@@ -3,11 +3,12 @@ FROM stackstorm/st2:${ST2_VERSION}
 LABEL com.stackstorm.component="st2actionrunner"
 
 # Install utils used by st2 'linux' pack, part of StackStorm core
-RUN apt-get install -y rsync \
-  inetutils-traceroute \
-  net-tools \
-  dnsutils \
-  sendmail \
+RUN apt-get -qq update \
+  && apt-get install -y rsync \
+    inetutils-traceroute \
+    net-tools \
+    dnsutils \
+    sendmail \
   && rm -rf /var/lib/apt/lists/* /var/cache/apt/archives/* \
   && apt-get clean
 

--- a/st2web/Dockerfile
+++ b/st2web/Dockerfile
@@ -41,7 +41,9 @@ RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys ABF5BD827B
   && echo "deb http://nginx.org/packages/ubuntu/ focal nginx" > /etc/apt/sources.list.d/nginx.list \
   && apt-get update \
   && apt-get install -y nginx \
-  && rm -f /etc/apt/sources.list.d/nginx.list
+  && rm -f /etc/apt/sources.list.d/nginx.list \
+  && rm -rf /var/lib/apt/lists/* /var/cache/apt/archives/* \
+  && apt-get clean
 
 # Install StackStorm Web UI
 RUN if [ "${ST2_VERSION#*dev}" != "${ST2_VERSION}" ]; then \
@@ -71,7 +73,9 @@ RUN if [ "${ST2_VERSION#*dev}" != "${ST2_VERSION}" ]; then \
   && rm -f /etc/nginx/conf.d/default.conf \
   && rm -f /tmp/st2.conf.patch \
   && rm -f /tmp/st2.conf-http.patch \
-  && rm -f /tmp/st2.conf-https.patch
+  && rm -f /tmp/st2.conf-https.patch \
+  && rm -rf /var/lib/apt/lists/* /var/cache/apt/archives/* \
+  && apt-get clean
 
 # It's a user's responsbility to pass the valid SSL certificate files: 'st2.key' and 'st2.crt', used in nginx
 VOLUME ["/etc/ssl/st2/"]


### PR DESCRIPTION
"WORKDIR" instruction should be used instead of "cd" commands (docker:S6597)
In Dockerfile, instructions RUN, CMD, and ENTRYPOINT can contain long shell scripts chaining multiple commands, including the cd command for changing directories. Using WORKDIR instruction instead reduces the complexity of the above instructions and makes them easier to read, understand, troubleshoot, and maintain.

Cache should be cleaned after package installation (docker:S6587)
Docker images should only contain necessary data. The package index is optional for the correct working of the installed software. Storing an index also increases the size of the Docker image. It should be reduced to speed up deployments and reduce storage and bandwidth.