### PR TITLE
Persistent Volume for Certs for LDAP

### DIFF
--- a/st2auth/Dockerfile
+++ b/st2auth/Dockerfile
@@ -4,6 +4,6 @@ LABEL com.stackstorm.component="st2auth"
 
 USER st2
 
-VOLUME ["/etc/st2/keys", "/opt/stackstorm/rbac"]
+VOLUME ["/etc/st2/keys", "/opt/stackstorm/rbac", "/etc/ssl/certs"]
 CMD ["/opt/stackstorm/st2/bin/st2auth", "--config-file=/etc/st2/st2.conf", "--config-file=/etc/st2/st2.docker.conf", "--config-file=/etc/st2/st2.user.conf"]
 EXPOSE 9100


### PR DESCRIPTION
This adds `/etc/ssl/certs` as a volume to `st2auth` so that any CA certs used by LDAP (when using LDAP) can be persisted between iterations of containers.