### PR TITLE
Explicitly force images be built for AMD64

### DIFF
--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:focal
+FROM --platform=linux/amd64 ubuntu:focal
 
 ARG DEBIAN_FRONTEND=noninteractive
 

--- a/st2actionrunner/Dockerfile
+++ b/st2actionrunner/Dockerfile
@@ -1,5 +1,5 @@
 ARG ST2_VERSION
-FROM stackstorm/st2:${ST2_VERSION}
+FROM --platform=linux/amd64 stackstorm/st2:${ST2_VERSION}
 LABEL com.stackstorm.component="st2actionrunner"
 
 # Install utils used by st2 'linux' pack, part of StackStorm core

--- a/st2api/Dockerfile
+++ b/st2api/Dockerfile
@@ -1,5 +1,5 @@
 ARG ST2_VERSION
-FROM stackstorm/st2:${ST2_VERSION}
+FROM --platform=linux/amd64 stackstorm/st2:${ST2_VERSION}
 LABEL com.stackstorm.component="st2api"
 
 USER st2

--- a/st2auth/Dockerfile
+++ b/st2auth/Dockerfile
@@ -1,5 +1,5 @@
 ARG ST2_VERSION
-FROM stackstorm/st2:${ST2_VERSION}
+FROM --platform=linux/amd64 stackstorm/st2:${ST2_VERSION}
 LABEL com.stackstorm.component="st2auth"
 
 USER st2

--- a/st2chatops/Dockerfile
+++ b/st2chatops/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:focal
+FROM --platform=linux/amd64 ubuntu:focal
 
 ARG DEBIAN_FRONTEND=noninteractive
 

--- a/st2garbagecollector/Dockerfile
+++ b/st2garbagecollector/Dockerfile
@@ -1,5 +1,5 @@
 ARG ST2_VERSION
-FROM stackstorm/st2:${ST2_VERSION}
+FROM --platform=linux/amd64 stackstorm/st2:${ST2_VERSION}
 LABEL com.stackstorm.component="st2garbagecollector"
 
 USER st2

--- a/st2notifier/Dockerfile
+++ b/st2notifier/Dockerfile
@@ -1,5 +1,5 @@
 ARG ST2_VERSION
-FROM stackstorm/st2:${ST2_VERSION}
+FROM --platform=linux/amd64 stackstorm/st2:${ST2_VERSION}
 LABEL com.stackstorm.component="st2notifier"
 
 USER st2

--- a/st2rulesengine/Dockerfile
+++ b/st2rulesengine/Dockerfile
@@ -1,5 +1,5 @@
 ARG ST2_VERSION
-FROM stackstorm/st2:${ST2_VERSION}
+FROM --platform=linux/amd64 stackstorm/st2:${ST2_VERSION}
 LABEL com.stackstorm.component="st2rulesengine"
 
 USER st2

--- a/st2scheduler/Dockerfile
+++ b/st2scheduler/Dockerfile
@@ -1,5 +1,5 @@
 ARG ST2_VERSION
-FROM stackstorm/st2:${ST2_VERSION}
+FROM --platform=linux/amd64 stackstorm/st2:${ST2_VERSION}
 LABEL com.stackstorm.component="st2scheduler"
 
 USER st2

--- a/st2sensorcontainer/Dockerfile
+++ b/st2sensorcontainer/Dockerfile
@@ -1,5 +1,5 @@
 ARG ST2_VERSION
-FROM stackstorm/st2:${ST2_VERSION}
+FROM --platform=linux/amd64 stackstorm/st2:${ST2_VERSION}
 LABEL com.stackstorm.component="st2sensorcontainer"
 
 USER st2

--- a/st2stream/Dockerfile
+++ b/st2stream/Dockerfile
@@ -1,5 +1,5 @@
 ARG ST2_VERSION
-FROM stackstorm/st2:${ST2_VERSION}
+FROM --platform=linux/amd64 stackstorm/st2:${ST2_VERSION}
 LABEL com.stackstorm.component="st2stream"
 
 USER st2

--- a/st2timersengine/Dockerfile
+++ b/st2timersengine/Dockerfile
@@ -1,5 +1,5 @@
 ARG ST2_VERSION
-FROM stackstorm/st2:${ST2_VERSION}
+FROM --platform=linux/amd64 stackstorm/st2:${ST2_VERSION}
 LABEL com.stackstorm.component="st2timersengine"
 
 USER st2

--- a/st2web/Dockerfile
+++ b/st2web/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:focal
+FROM --platform=linux/amd64 ubuntu:focal
 
 ARG DEBIAN_FRONTEND=noninteractive
 

--- a/st2workflowengine/Dockerfile
+++ b/st2workflowengine/Dockerfile
@@ -1,5 +1,5 @@
 ARG ST2_VERSION
-FROM stackstorm/st2:${ST2_VERSION}
+FROM --platform=linux/amd64 stackstorm/st2:${ST2_VERSION}
 LABEL com.stackstorm.component="st2workflowengine"
 
 USER st2


### PR DESCRIPTION
Add `--platform=linux/amd64` to all `FROM` lines in the st2 Dockerfiles.

With the advent of ARM64 Apple Mac's, building Docker images on these machines will default to build ARM64 images (which StackStorm doesn't support) unless explicitly stated otherwise.

This PR makes the architecture declaration for St2 Docker images to be explicitly AMD64.