### PR TITLE
Update PGP Signing Key for NGINX Apt Repo

### DIFF
--- a/st2web/Dockerfile
+++ b/st2web/Dockerfile
@@ -37,7 +37,7 @@ RUN apt-get -qq update \
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 
 # Install nginx
-RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys ABF5BD827BD9BF62 \
+RUN curl https://nginx.org/keys/nginx_signing.key | gpg --dearmor | apt-key add - \
   && echo "deb http://nginx.org/packages/ubuntu/ focal nginx" > /etc/apt/sources.list.d/nginx.list \
   && apt-get update \
   && apt-get install -y nginx \


### PR DESCRIPTION
NGINX updated their PGP signing keys (https://blog.nginx.org/blog/updating-pgp-key-for-nginx-software), the old one has since expired - and the new key hasn't been publish to the ubuntu key server (`hkp://keyserver.ubuntu.com:80`) - See https://trac.nginx.org/nginx/ticket/2654. So builds of `st2web` have started failing.

This PR adapts the steps from the above NGINX blog article to fix the builds (by pulling the key from the source NGINX uses in the article).
