### PR TITLE
Replace ubuntu focal with jammy

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,22 @@ DOCKER_TAG ?= ${ST2_VERSION}
 RELEASE_TAG_REGEX := [^dev]$$
 SHELL := /bin/bash
 
+# Determine the base image based on ST2_VERSION
+# For ST2_VERSION 3.8.* and 3.8dev, use ubuntu:focal
+# For ST2_VERSION 3.9.* and 3.9dev, use ubuntu:jammy
+# NOTE - Once we have a stable release of 3.9, we will need to update this
+# to use ubuntu:jammy for all 3.9 versions and remove the check for 3.9dev
+BASE_IMAGE := $(shell \
+	if [[ "${ST2_VERSION}" =~ ^'3.8'('.'[0-9]+|dev)?$$ ]]; then \
+		echo "ubuntu:focal"; \
+	elif [[ "${ST2_VERSION}" =~ ^'3.9'('.'[0-9]+|dev)?$$ ]]; then \
+		echo "ubuntu:jammy"; \
+	else \
+		echo "ERROR: Unsupported ST2_VERSION '${ST2_VERSION}'" >&2; \
+		exit 1; \
+	fi \
+)
+
 # supported values of the TAG_UPDATE_FLAG
 # 0 = no additional tags to be set
 # 1 = add the major.minor tag
@@ -26,16 +42,18 @@ build: verify_tag_update_flag
 		--pull \
 		--no-cache \
 		--build-arg ST2_VERSION=${ST2_VERSION} \
+		--build-arg BASE_IMAGE=${BASE_IMAGE} \
 		-t stackstorm/st2:${DOCKER_TAG} base/
-	@echo -e "\033[32mSuccessfully built \033[1mstackstorm/st2:${DOCKER_TAG}\033[0m\033[32m common Docker image with StackStorm version \033[1m${ST2_VERSION}\033[0m"
+	@echo -e "\033[32mSuccessfully built \033[1mstackstorm/st2:${DOCKER_TAG}\033[0m\033[32m common Docker image with StackStorm version \033[1m${ST2_VERSION}\033[0m (Base: ${BASE_IMAGE})"
 	@set -e; \
 	for component in st2*; do \
 		docker build \
 			--no-cache \
 			--build-arg ST2_VERSION=${ST2_VERSION} \
+			--build-arg BASE_IMAGE=${BASE_IMAGE} \
 			--tag stackstorm/$$component:${DOCKER_TAG} \
 			$$component/; \
-		echo -e "\033[32mSuccessfully built \033[1mstackstorm/$$component:${DOCKER_TAG}\033[0m\033[32m Docker image for StackStorm version \033[1m${ST2_VERSION}\033[0m"; \
+		echo -e "\033[32mSuccessfully built \033[1mstackstorm/$$component:${DOCKER_TAG}\033[0m\033[32m Docker image for StackStorm version \033[1m${ST2_VERSION}\033[0m (Base: ${BASE_IMAGE})"; \
 	done
 ifeq ($(RELEASE_VERSION), true)
 ifeq ($(TAG_UPDATE_FLAG), 1)

--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -1,4 +1,7 @@
-FROM --platform=linux/amd64 ubuntu:jammy
+# Use dynamically set base image
+# Default base image is Ubuntu 22.04 (jammy)
+ARG BASE_IMAGE=ubuntu:jammy
+FROM --platform=linux/amd64 ${BASE_IMAGE}
 
 ARG DEBIAN_FRONTEND=noninteractive
 

--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 ubuntu:focal
+FROM --platform=linux/amd64 ubuntu:jammy
 
 ARG DEBIAN_FRONTEND=noninteractive
 
@@ -34,7 +34,7 @@ ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 
 # Install StackStorm, but without UI
 RUN if [ "${ST2_VERSION#*dev}" != "${ST2_VERSION}" ]; then \
-    ST2_REPO=unstable; \
+    ST2_REPO=staging-unstable; \
   else \
     ST2_REPO=stable; \
   fi \

--- a/st2chatops/Dockerfile
+++ b/st2chatops/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 ubuntu:focal
+FROM --platform=linux/amd64 ubuntu:jammy
 
 ARG DEBIAN_FRONTEND=noninteractive
 
@@ -41,13 +41,13 @@ ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 
 # Install st2chatops
 RUN if [ "${ST2_VERSION#*dev}" != "${ST2_VERSION}" ]; then \
-    ST2_REPO=unstable; \
+    ST2_REPO=staging-unstable; \
   else \
     ST2_REPO=stable; \
   fi \
   && echo ST2_REPO=${ST2_REPO} \
   && curl -s https://packagecloud.io/install/repositories/StackStorm/${ST2_REPO}/script.deb.sh | bash \
-  && curl -sL https://deb.nodesource.com/setup_14.x | bash - \
+  && curl -sL https://deb.nodesource.com/setup_20.x | bash - \
   && apt-get install -y st2chatops=${ST2_VERSION}-* \
   && rm -f /etc/apt/sources.list.d/nodesource.list \
   && rm -f /etc/apt/sources.list.d/StackStorm_*.list

--- a/st2chatops/Dockerfile
+++ b/st2chatops/Dockerfile
@@ -1,4 +1,7 @@
-FROM --platform=linux/amd64 ubuntu:jammy
+# Use dynamically set base image
+# Default base image is Ubuntu 22.04 (jammy)
+ARG BASE_IMAGE=ubuntu:jammy
+FROM --platform=linux/amd64 ${BASE_IMAGE}
 
 ARG DEBIAN_FRONTEND=noninteractive
 

--- a/st2web/Dockerfile
+++ b/st2web/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 ubuntu:focal
+FROM --platform=linux/amd64 ubuntu:jammy
 
 ARG DEBIAN_FRONTEND=noninteractive
 
@@ -38,14 +38,14 @@ ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 
 # Install nginx
 RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys ABF5BD827BD9BF62 \
-  && echo "deb http://nginx.org/packages/ubuntu/ focal nginx" > /etc/apt/sources.list.d/nginx.list \
+  && echo "deb http://nginx.org/packages/ubuntu/ jammy nginx" > /etc/apt/sources.list.d/nginx.list \
   && apt-get update \
   && apt-get install -y nginx \
   && rm -f /etc/apt/sources.list.d/nginx.list
 
 # Install StackStorm Web UI
 RUN if [ "${ST2_VERSION#*dev}" != "${ST2_VERSION}" ]; then \
-    ST2_REPO=unstable; \
+    ST2_REPO=staging-unstable; \
   else \
     ST2_REPO=stable; \
   fi \

--- a/st2web/Dockerfile
+++ b/st2web/Dockerfile
@@ -1,4 +1,7 @@
-FROM --platform=linux/amd64 ubuntu:jammy
+# Use dynamically set base image
+# Default base image is Ubuntu 22.04 (jammy)
+ARG BASE_IMAGE=ubuntu:jammy
+FROM --platform=linux/amd64 ${BASE_IMAGE}
 
 ARG DEBIAN_FRONTEND=noninteractive
 


### PR DESCRIPTION
Replace ubuntu focal with jammy

- Update Dockerfiles for ubuntu jammy for base/ , st2chatops/ and st2web/ components

- Correct staging package source

- Update nodesource setup version in st2chatops, compatible with jammy