### PR TITLE
Fix: st2 3.9 migration - Fix welcome message

### DIFF
--- a/base/files/.welcome.sh
+++ b/base/files/.welcome.sh
@@ -1,8 +1,11 @@
 #!/bin/bash
 
-# Get st2 version based on hardcoded string in st2common
-ST2_VERSION=$(/opt/stackstorm/st2/bin/python -c 'exec(open("/opt/stackstorm/st2/lib/python3.8/site-packages/st2common/__init__.py").read()); print(__version__)')
+# Get Ubuntu version
 UBUNTU_VERSION=$(lsb_release -s -d)
+
+VERSIONFILE=$(ls /opt/stackstorm/st2/lib/python*/site-packages/st2common/__init__.py)
+ST2_VERSION=$(/opt/stackstorm/st2/bin/python -c "exec(open('$VERSIONFILE').read()); print(__version__)")
+
 printf "Welcome to \033[1;38;5;208mStackStorm HA\033[0m \033[1m%s\033[0m (${UBUNTU_VERSION} %s %s)\n" "v${ST2_VERSION}" "$(uname -o)" "$(uname -m)"
 printf " * Documentation: https://docs.stackstorm.com/\n"
 printf " * Community: https://stackstorm.com/community-signup\n"

--- a/base/files/.welcome.sh
+++ b/base/files/.welcome.sh
@@ -2,7 +2,6 @@
 
 # Get Ubuntu version
 UBUNTU_VERSION=$(lsb_release -s -d)
-
 VERSIONFILE=$(ls /opt/stackstorm/st2/lib/python*/site-packages/st2common/__init__.py)
 ST2_VERSION=$(/opt/stackstorm/st2/bin/python -c "exec(open('$VERSIONFILE').read()); print(__version__)")
 


### PR DESCRIPTION
Fix: Welcome message inside containers

Due to 3.9 migration python3.10 is default
and hence the version grep with hardcoded python3.8 fails.
